### PR TITLE
Split Fleet Types and squash some bugs

### DIFF
--- a/The US Navy.cat
+++ b/The US Navy.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="764e-277a-ff05-fdc6" name="The US Navy" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="d551-9646-dd17-819a" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="764e-277a-ff05-fdc6" name="The US Navy" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="d551-9646-dd17-819a" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="0dc1-d61d-4554-08ed" name="Portland-Class Cruiser" hidden="false" collective="false" import="true" targetId="b8aa-d7c0-c29e-3d4d" type="selectionEntry">
       <categoryLinks>
@@ -478,6 +478,7 @@
               </infoLinks>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="629f-88f0-bf96-8e42" name="Portland Refit 1942" hidden="false" collective="false" import="true" type="model">
@@ -578,6 +579,7 @@
               </infoLinks>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1ee-5008-b1f3-33b9" name="Portland Refit 1943" hidden="false" collective="false" import="true" type="model">
@@ -678,6 +680,7 @@
               </infoLinks>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a71-2437-bf90-27be" name="Portland Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -778,11 +781,13 @@
               </infoLinks>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="43e6-371e-ff14-030a" name="Indianapolis" hidden="false" collective="false" import="true" type="upgrade">
@@ -880,6 +885,7 @@
               </infoLinks>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46d2-10fd-aa01-98a9" name="Indianapolis Refit 1942" hidden="false" collective="false" import="true" type="model">
@@ -980,6 +986,7 @@
               </infoLinks>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4580-d793-be66-a505" name="Indianapolis Refit 1943" hidden="false" collective="false" import="true" type="model">
@@ -1080,6 +1087,7 @@
               </infoLinks>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5aa5-235f-0c0a-8d9f" name="Indianapolis Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -1180,16 +1188,19 @@
               </infoLinks>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="140.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e263-566d-80fa-dc10" name="New Mexico-Class Battleship" hidden="false" collective="false" import="true" type="upgrade">
@@ -1343,6 +1354,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2c45-15b8-3946-b0fb" name="New Mexico 1941" hidden="false" collective="false" import="true" type="upgrade">
@@ -1482,6 +1494,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0323-f059-c2e1-8c98" name="New Mexico 1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -1621,6 +1634,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9628-0592-686b-c501" name="New Mexico 1944" hidden="false" collective="false" import="true" type="upgrade">
@@ -1763,6 +1777,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="85.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="70e9-753b-4fee-8fa1" name="New Mexico 1945" hidden="false" collective="false" import="true" type="upgrade">
@@ -1884,6 +1899,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="110.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -1891,6 +1907,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a537-e507-5090-8441" name="Idaho" hidden="false" collective="false" import="true" type="upgrade">
@@ -2027,26 +2044,31 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="155.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9278-c82b-3bd4-9973" name="Idaho" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f930-fc48-895e-0f36" name="Idaho 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="43ae-748d-4865-6924" name="Idaho 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="70.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d5e7-cd9f-3570-fdf1" name="Idaho 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="85.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -2054,6 +2076,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d3da-5af5-0e46-0833" name="Mississippi" hidden="false" collective="false" import="true" type="upgrade">
@@ -2201,6 +2224,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="510e-0151-aeec-1ec0" name="Mississippi Refit 1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -2340,6 +2364,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="66bb-6106-daff-4622" name="Mississippi Refit 1944" hidden="false" collective="false" import="true" type="upgrade">
@@ -2482,6 +2507,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="75.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0d64-e67d-568a-77cb" name="Mississippi Refit 1945" hidden="false" collective="false" import="true" type="upgrade">
@@ -2610,6 +2636,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="135.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -2617,11 +2644,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="395.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c180-c89e-d9e2-b1ec" name="Fletcher-Class Destroyer" hidden="false" collective="false" import="true" type="unit">
@@ -2722,6 +2751,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fd92-ffa3-ecb0-cc60" name="Fletcher 1942" hidden="false" collective="false" import="true" type="upgrade">
@@ -2808,6 +2838,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fac3-ddc6-03da-b21e" name="Fletcher 1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -2894,6 +2925,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5ab0-1d99-e17c-d430" name="Fletcher 1944" hidden="false" collective="false" import="true" type="upgrade">
@@ -2980,6 +3012,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -2987,6 +3020,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e44c-11c8-1282-6a8b" name="Nicholas" hidden="false" collective="false" import="true" type="model">
@@ -3081,6 +3115,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="827b-7273-bc69-81aa" name="Nicholas 1942" hidden="false" collective="false" import="true" type="upgrade">
@@ -3167,6 +3202,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e49b-6985-00ba-ae53" name="Nicholas 1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -3253,6 +3289,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8d23-e4af-efa7-2e96" name="Nicholas 1944" hidden="false" collective="false" import="true" type="upgrade">
@@ -3339,6 +3376,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -3346,6 +3384,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3fc4-1256-12ac-4efb" name="O&apos;Bannon" hidden="false" collective="false" import="true" type="model">
@@ -3440,6 +3479,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="04cd-db66-f578-b9b5" name="O&apos;Bannon 1942" hidden="false" collective="false" import="true" type="upgrade">
@@ -3526,6 +3566,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8433-7052-73c8-5024" name="O&apos;Bannon 1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -3612,6 +3653,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b232-528a-3713-0b80" name="O&apos;Bannon 1944" hidden="false" collective="false" import="true" type="upgrade">
@@ -3698,6 +3740,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -3705,6 +3748,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="04f3-d80f-581d-995b" name="Jenkins" hidden="false" collective="false" import="true" type="model">
@@ -3799,6 +3843,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bbca-14f5-8794-3cee" name="Jenkins 1942-1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -3888,6 +3933,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3781-87c8-9163-6e2a" name="Jenkins 1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -3977,6 +4023,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8e98-e3a6-4232-9708" name="Jenkins 1944" hidden="false" collective="false" import="true" type="upgrade">
@@ -4066,6 +4113,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -4073,6 +4121,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1104-7065-84b6-b06c" name="Stevens" hidden="false" collective="false" import="true" type="model">
@@ -4167,6 +4216,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7063-4bcf-bfd3-6d23" name="Stevens 1942-1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -4256,6 +4306,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ed80-506c-46df-ef2c" name="Stevens 1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -4345,6 +4396,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ad12-b5e3-3f97-8027" name="Stevens 1944" hidden="false" collective="false" import="true" type="upgrade">
@@ -4434,6 +4486,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -4441,6 +4494,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d57c-4c86-470e-f9ff" name="Halford" hidden="false" collective="false" import="true" type="model">
@@ -4535,6 +4589,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0b81-4ef0-544b-a45d" name="Halford 1942-1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -4624,6 +4679,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="511d-7cba-a32a-908d" name="Halford 1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -4713,6 +4769,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="145d-10dc-2a8f-dfb9" name="Halford 1944" hidden="false" collective="false" import="true" type="upgrade">
@@ -4802,6 +4859,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -4809,6 +4867,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="acae-9ad4-737c-8ea2" name="Fletcher-Class " hidden="false" collective="false" import="true" type="model">
@@ -4903,6 +4962,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cc3a-6fb5-7be3-3cdf" name="Fletcher-Class 1942" hidden="false" collective="false" import="true" type="upgrade">
@@ -4989,6 +5049,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f2bd-0827-d49e-d86d" name="Fletcher-Class 1943" hidden="false" collective="false" import="true" type="upgrade">
@@ -5075,6 +5136,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0ce7-3658-935d-9b39" name="Fletcher-Class 1944" hidden="false" collective="false" import="true" type="upgrade">
@@ -5161,6 +5223,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d4e6-d43d-9f65-4910" name="Fletcher-Class 1945 - Radar Pickets" hidden="false" collective="false" import="true" type="upgrade">
@@ -5247,6 +5310,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -5254,11 +5318,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2e47-ccf3-f53c-78c5" name="Essex-Class Aircraft Carrier" hidden="false" collective="false" import="true" type="unit">
@@ -5353,6 +5419,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="17ed-8d29-42b4-d726" name="Essex Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -5439,11 +5506,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e272-434d-07b0-d5b8" name="Shangri-La" hidden="false" collective="false" import="true" type="upgrade">
@@ -5532,6 +5601,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1691-0b2e-1c42-6a67" name="Shangri-La Refit 1944" hidden="false" collective="false" import="true" type="model">
@@ -5618,6 +5688,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d37b-a2c0-aa46-e7ff" name="Shangri-La Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -5704,11 +5775,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="707f-fc58-a510-9c79" name="Franklin" hidden="false" collective="false" import="true" type="upgrade">
@@ -5797,11 +5870,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="589f-dbc2-2111-defb" name="Bennington" hidden="false" collective="false" import="true" type="upgrade">
@@ -5890,6 +5965,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f448-01e5-f65f-b871" name="Bennington Refit 1944" hidden="false" collective="false" import="true" type="model">
@@ -5976,6 +6052,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="179e-f5ea-e62b-d70c" name="Bennington Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -6062,11 +6139,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0caa-7bdc-d56a-81b3" name="Bon Homme Richard" hidden="false" collective="false" import="true" type="upgrade">
@@ -6155,6 +6234,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9495-e533-9683-b738" name="Bon Homme Richard Refit 1944" hidden="false" collective="false" import="true" type="model">
@@ -6241,6 +6321,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27f0-78ec-fcfc-1649" name="Bon Homme Richard Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -6327,11 +6408,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9dfb-cdd6-ba1e-1565" name="Randolph" hidden="false" collective="false" import="true" type="upgrade">
@@ -6420,6 +6503,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f4c-6de9-5fba-2b7f" name="Randolph Refit 1944" hidden="false" collective="false" import="true" type="model">
@@ -6506,6 +6590,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2278-e5fd-3698-009f" name="Randolph Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -6592,11 +6677,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="655d-ac55-d5ab-5452" name="Intrepid" hidden="false" collective="false" import="true" type="upgrade">
@@ -6685,6 +6772,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="437c-e176-119f-5c70" name="Intrepid Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -6771,11 +6859,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b534-3aa3-12a9-8d49" name="Yorktown" hidden="false" collective="false" import="true" type="upgrade">
@@ -6864,6 +6954,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3556-70d0-2908-ff9e" name="Yorktown Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -6950,11 +7041,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cc59-59aa-d9a5-56a9" name="Lexington" hidden="false" collective="false" import="true" type="upgrade">
@@ -7043,6 +7136,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65d2-bdc8-ff3c-a3c5" name="Lexington Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -7129,11 +7223,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2c1f-09d9-dec1-4354" name="Bunker Hill" hidden="false" collective="false" import="true" type="upgrade">
@@ -7222,6 +7318,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24da-e6d5-157b-ca91" name="Bunker Hill Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -7308,11 +7405,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8805-5a68-acf2-396a" name="Wasp" hidden="false" collective="false" import="true" type="upgrade">
@@ -7401,6 +7500,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2bf6-7bc8-da23-6bae" name="Wasp Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -7487,11 +7587,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d499-eb22-3ed0-7057" name="Antietam" hidden="false" collective="false" import="true" type="upgrade">
@@ -7580,6 +7682,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f90-aba2-f791-d31c" name="Antietam Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -7666,11 +7769,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f3df-f52b-4ff5-4409" name="Princeton" hidden="false" collective="false" import="true" type="upgrade">
@@ -7759,6 +7864,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f55-5cf4-8c08-f6b4" name="Princeton Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -7845,11 +7951,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="171b-de78-ba8d-7493" name="Lake Champaign" hidden="false" collective="false" import="true" type="upgrade">
@@ -7938,6 +8046,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f0a-c110-170e-6ae8" name="Lake Champaign Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -8024,11 +8133,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fe5e-4ee7-b2d8-6437" name="Tarawa" hidden="false" collective="false" import="true" type="upgrade">
@@ -8117,6 +8228,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fbf1-7cd0-b4f7-e9f0" name="Tarawa Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -8203,11 +8315,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e450-8c5b-a5ba-17d6" name="Hornet" hidden="false" collective="false" import="true" type="upgrade">
@@ -8296,6 +8410,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7c4-e26a-2b4a-211e" name="Hornet Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -8382,11 +8497,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c797-4382-00bd-6758" name="Boxer" hidden="false" collective="false" import="true" type="upgrade">
@@ -8475,6 +8592,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90af-5c45-c106-e708" name="Boxer" hidden="false" collective="false" import="true" type="model">
@@ -8561,11 +8679,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c65a-1718-ef08-9905" name="Ticonderoga" hidden="false" collective="false" import="true" type="upgrade">
@@ -8654,6 +8774,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c078-8c0a-7281-be2d" name="Ticonderoga" hidden="false" collective="false" import="true" type="model">
@@ -8740,11 +8861,13 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c2ae-65bc-b04b-ec1e" name="Hancock" hidden="false" collective="false" import="true" type="upgrade">
@@ -8833,6 +8956,7 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbd1-88d3-aa40-6b7a" name="Hancock" hidden="false" collective="false" import="true" type="model">
@@ -8919,88 +9043,27 @@
               </rules>
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="0254-8c1b-0643-4b16" name="Corsair Flights" hidden="false" collective="false" import="true">
+      <entryLinks>
+        <entryLink id="3d9b-63ad-73a4-333d" name="Carrier Flights" hidden="false" collective="false" import="true" targetId="df8d-b7fa-ee1b-5a91" type="selectionEntryGroup">
           <constraints>
-            <constraint field="selections" scope="parent" value="22.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bfd-e5cf-af37-e280" type="max"/>
-            <constraint field="selections" scope="parent" value="22.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="418c-039b-7805-1281" type="min"/>
+            <constraint field="selections" scope="parent" value="22.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e74-3022-140c-f432" type="min"/>
+            <constraint field="selections" scope="parent" value="22.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a57-8a74-8dc8-3b6c" type="max"/>
           </constraints>
-          <rules>
-            <rule id="0b65-7222-24fb-f832" name="Tough" hidden="false">
-              <description>Two hits are needed from a single AA battery system in order to destroy it.</description>
-            </rule>
-          </rules>
-          <selectionEntries>
-            <selectionEntry id="a403-df8c-06ce-a6c7" name="Vought F4U-1 Corsair 1942" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="cd9e-bb80-d82a-af31" name="Vought F4U-1 Corsair" hidden="false" typeId="94d1-ba1c-98de-f273" typeName="Aircraft">
-                  <characteristics>
-                    <characteristic name="Flight" typeId="9d24-de86-2e13-2aa2">Vought F4U-1 Corsair</characteristic>
-                    <characteristic name="Carrier Capable" typeId="82c4-41a8-080d-5ee3">No</characteristic>
-                    <characteristic name="Role" typeId="81db-f323-b61e-5f1f">Fighter</characteristic>
-                    <characteristic name="Flank Speed" typeId="e29b-b9eb-d470-d6f8">30&quot;</characteristic>
-                    <characteristic name="Dogfight" typeId="bbad-b699-5476-bdfc">+3</characteristic>
-                    <characteristic name="Damage Dice" typeId="7241-6bab-e1b3-41a5">0</characteristic>
-                    <characteristic name="Traits" typeId="480e-9141-ccd3-fb18">Tough</characteristic>
-                    <characteristic name="Points" typeId="4987-2d92-bb96-5dd5"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="00a4-49e6-4222-17f0" name="Vought F4U-1 Corsair 1944 Bomber" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="73e5-436c-cf34-7c61" name="Vought F4U-1 Corsair" hidden="false" typeId="94d1-ba1c-98de-f273" typeName="Aircraft">
-                  <characteristics>
-                    <characteristic name="Flight" typeId="9d24-de86-2e13-2aa2">Vought F4U-1 Corsair</characteristic>
-                    <characteristic name="Carrier Capable" typeId="82c4-41a8-080d-5ee3">Yes</characteristic>
-                    <characteristic name="Role" typeId="81db-f323-b61e-5f1f">Bomber</characteristic>
-                    <characteristic name="Flank Speed" typeId="e29b-b9eb-d470-d6f8">32&quot;</characteristic>
-                    <characteristic name="Dogfight" typeId="bbad-b699-5476-bdfc">+3</characteristic>
-                    <characteristic name="Damage Dice" typeId="7241-6bab-e1b3-41a5">4</characteristic>
-                    <characteristic name="Traits" typeId="480e-9141-ccd3-fb18">Tough</characteristic>
-                    <characteristic name="Points" typeId="4987-2d92-bb96-5dd5"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e81d-3978-2893-60b9" name="Vought F4U-1 Corsair 1944 Fighter" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="edff-de01-abe5-5eef" name="Vought F4U-1 Corsair" hidden="false" typeId="94d1-ba1c-98de-f273" typeName="Aircraft">
-                  <characteristics>
-                    <characteristic name="Flight" typeId="9d24-de86-2e13-2aa2">Vought F4U-1 Corsair</characteristic>
-                    <characteristic name="Carrier Capable" typeId="82c4-41a8-080d-5ee3">Yes</characteristic>
-                    <characteristic name="Role" typeId="81db-f323-b61e-5f1f">Fighter</characteristic>
-                    <characteristic name="Flank Speed" typeId="e29b-b9eb-d470-d6f8">32&quot;</characteristic>
-                    <characteristic name="Dogfight" typeId="bbad-b699-5476-bdfc">+4</characteristic>
-                    <characteristic name="Damage Dice" typeId="7241-6bab-e1b3-41a5">0</characteristic>
-                    <characteristic name="Traits" typeId="480e-9141-ccd3-fb18">Tough</characteristic>
-                    <characteristic name="Points" typeId="4987-2d92-bb96-5dd5"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="270.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7dc1-fd5f-2f0d-e55c" name="Pennsylvania-Class Battleship" hidden="false" collective="false" import="true" type="unit">
@@ -9154,6 +9217,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="247e-1fb2-8bde-0c8b" name="Arizona 1941" hidden="false" collective="false" import="true" type="model">
@@ -9293,6 +9357,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -9300,6 +9365,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5df9-a464-3c94-677a" name="Pennsylvania" hidden="false" collective="false" import="true" type="upgrade">
@@ -9447,6 +9513,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="978a-2d2a-122a-c2e8" name="Pennsylvania 1941" hidden="false" collective="false" import="true" type="model">
@@ -9586,6 +9653,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d156-dc82-1306-a0cf" name="Pennsylvania 1942" hidden="false" collective="false" import="true" type="model">
@@ -9728,6 +9796,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="90.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="061a-4e25-6efd-36a9" name="Pennsylvania 1943" hidden="false" collective="false" import="true" type="model">
@@ -9856,6 +9925,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="120.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0b8b-f362-4b93-562e" name="Pennsylvania 1945" hidden="false" collective="false" import="true" type="model">
@@ -9984,6 +10054,7 @@
                   </rules>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="120.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -9991,11 +10062,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="390.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6231-7c07-fa31-af05" name="Cimarron-Class Oil Tanker" hidden="false" collective="false" import="true" type="unit">
@@ -10061,6 +10134,7 @@
           </rules>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="79e4-6dff-15e6-3719" name="Cimarron-Class Oil Tanker 1942" hidden="false" collective="false" import="true" type="model">
@@ -10124,6 +10198,7 @@
           </rules>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6e38-7dee-390a-5d6b" name="Cimarron-Class Oil Tanker 1944" hidden="false" collective="false" import="true" type="model">
@@ -10187,11 +10262,13 @@
           </rules>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="00b0-0957-fbc0-7211" name="Colorado-Class Battleship" hidden="false" collective="false" import="true" type="unit">
@@ -10211,26 +10288,31 @@
                 <selectionEntry id="6c17-fe50-3f9d-933e" name="Colorado" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3468-9fa0-da16-8499" name="Colorado 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1bda-513a-dd32-417d" name="Colorado 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="85.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dc7a-0ec4-d650-1d92" name="Colorado 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="105.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="47ce-3083-ed6c-34c9" name="Colorado 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="115.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -10238,6 +10320,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ce31-1f48-0f7d-3129" name="Maryland" hidden="false" collective="false" import="true" type="model">
@@ -10251,31 +10334,37 @@
                 <selectionEntry id="488c-76cf-beb6-2509" name="Maryland" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="eada-57a4-095d-5dfc" name="Maryland 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bae3-1351-176d-0846" name="Maryland 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="440e-832e-ac85-9250" name="Maryland 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="95.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="31b3-0d55-07fa-9e6b" name="Maryland 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="110.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f8f7-4bcd-bc00-18d6" name="Maryland 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="155.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -10283,6 +10372,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="36be-11e1-d8c0-f8c2" name="West Virginia" hidden="false" collective="false" import="true" type="model">
@@ -10296,21 +10386,25 @@
                 <selectionEntry id="a4ad-ec40-ce52-2d51" name="West Virginia" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4a0a-a109-d0dc-afd0" name="West Virginia 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1850-1ab8-2265-0e35" name="West Virginia 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="115.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8bc8-aea9-7a4a-dde8" name="West Virginia 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="120.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -10318,11 +10412,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="400.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="51bf-7215-dcf8-b6f0" name="Iowa-Class Battleship" hidden="false" collective="false" import="true" type="unit">
@@ -10440,6 +10536,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="559e-3c65-0473-dd7e" name="Iowa Refit 1944" hidden="false" collective="false" import="true" type="model">
@@ -10543,6 +10640,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7155-2f54-2849-ffbe" name="Iowa Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -10646,6 +10744,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -10653,6 +10752,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="06e9-1fa8-8995-3811" name="Missouri" hidden="false" collective="false" import="true" type="model">
@@ -10764,6 +10864,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dcfe-4f80-a84a-4903" name="Missouri Refit 1944" hidden="false" collective="false" import="true" type="model">
@@ -10867,6 +10968,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c403-9752-1090-8d10" name="Missouri Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -10970,6 +11072,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -10977,6 +11080,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e65a-7cde-d022-36f3" name="New Jersey" hidden="false" collective="false" import="true" type="model">
@@ -11088,6 +11192,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ca77-37ed-79d4-be2c" name="New Jersey Refit 1943" hidden="false" collective="false" import="true" type="model">
@@ -11191,6 +11296,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d3bc-dd55-10c3-2c98" name="New Jersey Refit 1945" hidden="false" collective="false" import="true" type="model">
@@ -11294,6 +11400,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11301,6 +11408,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1eae-0920-9a47-a6a7" name="Wisconsin" hidden="false" collective="false" import="true" type="model">
@@ -11412,6 +11520,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cba5-7300-1922-fe61" name="Wisconsin Refit 1944" hidden="false" collective="false" import="true" type="model">
@@ -11515,6 +11624,7 @@
                   </categoryLinks>
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11522,11 +11632,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="850.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="efe9-9407-7976-2282" name="Montana-Class Battleship" hidden="false" collective="false" import="true" type="unit">
@@ -11546,6 +11658,7 @@
                 <selectionEntry id="dc01-126c-2af7-f953" name="Montana" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11553,6 +11666,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1c20-5946-e5b5-77b7" name="Louisiana" hidden="false" collective="false" import="true" type="model">
@@ -11566,6 +11680,7 @@
                 <selectionEntry id="7949-7528-b1ee-18a4" name="Louisiana" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11573,6 +11688,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3db1-1c33-966c-f5f3" name="Maine" hidden="false" collective="false" import="true" type="model">
@@ -11586,6 +11702,7 @@
                 <selectionEntry id="61a1-c36c-a623-40ff" name="Maine" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11593,6 +11710,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b8d3-ac63-1b07-e678" name="Hew Hampshire" hidden="false" collective="false" import="true" type="model">
@@ -11606,6 +11724,7 @@
                 <selectionEntry id="636a-2d92-e6da-cfff" name="New Hampshire" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11613,6 +11732,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="204f-7f23-df49-7207" name="Ohio" hidden="false" collective="false" import="true" type="model">
@@ -11626,6 +11746,7 @@
                 <selectionEntry id="24f5-7f84-e838-b740" name="Ohio" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11633,11 +11754,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="950.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f180-c1ac-7f8b-1700" name="Nevada-Class Battleship" hidden="false" collective="false" import="true" type="unit">
@@ -11657,21 +11780,25 @@
                 <selectionEntry id="6393-917b-278b-f292" name="Nevada" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5e9a-3eb7-69d2-856a" name="Nevada 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="125.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d7fd-399e-0461-e981" name="Nevada 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="120.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="db53-0c42-17cc-ae6b" name="Nevada 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="125.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11679,6 +11806,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e018-2883-39ec-52c6" name="Oklahoma" hidden="false" collective="false" import="true" type="model">
@@ -11692,11 +11820,13 @@
                 <selectionEntry id="ee19-76f0-14e7-2645" name="Oklahoma" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="128d-e98f-e41f-20d4" name="Oklahoma 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11704,11 +11834,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="390.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8b82-2aa0-92f3-e252" name="New York-Class Battleship" hidden="false" collective="false" import="true" type="unit">
@@ -11728,31 +11860,37 @@
                 <selectionEntry id="4ba0-2f9f-6851-fa49" name="New York" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="10b0-6d7b-ac1c-edd4" name="New York 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a283-4df2-195f-1abe" name="New York 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8d09-08d2-7c65-aa13" name="New York 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="75.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="afc6-b3ac-3a09-a2a4" name="New York 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="85.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="97aa-d4d5-85a7-cc13" name="New York 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="90.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11760,6 +11898,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5856-5b10-2ec1-f17a" name="Texas" hidden="false" collective="false" import="true" type="model">
@@ -11773,31 +11912,37 @@
                 <selectionEntry id="7e9e-f80a-2f50-28a4" name="Texas" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bc25-2e92-24b0-74b3" name="Texas 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9dae-7138-90b8-eb29" name="Texas 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0710-70eb-5cea-0252" name="Texas 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="75.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cc9b-62ef-03a4-45f9" name="Texas 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="85.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4d74-dc0e-e272-bb37" name="Texas 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="90.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11805,11 +11950,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="350.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="abb4-2e2f-6ae4-8e78" name="North Carolina-Class Battleship" hidden="false" collective="false" import="true" type="unit">
@@ -11829,26 +11976,31 @@
                 <selectionEntry id="e790-9b7a-bce7-0be1" name="North Carolina" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7929-688e-01ad-35f0" name="North Carolina 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="95.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a8b3-ff6a-0505-73c8" name="North Carolina 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="140.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="88c1-7c6e-e4c8-2864" name="North Carolina 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="225.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="398f-b0e8-bb81-b09d" name="North Carolina 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="220.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11856,6 +12008,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="57fb-7de3-4431-f05a" name="Washington" hidden="false" collective="false" import="true" type="model">
@@ -11869,26 +12022,31 @@
                 <selectionEntry id="8c08-51f0-793a-5928" name="Washington" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0b62-6941-e0ea-7cf2" name="Washington 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="95.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3fe8-d380-ec0e-05cc" name="Washington 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="150.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6179-55cc-09a0-3dc7" name="Washington 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="230.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a7ff-e851-d381-35dc" name="Washington 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="235.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11896,11 +12054,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="800.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="748c-adc3-b001-ade3" name="South Dakota-Class Battleship" hidden="false" collective="false" import="true" type="unit">
@@ -11920,26 +12080,31 @@
                 <selectionEntry id="a05e-70cb-b68d-42d6" name="South Dakota" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9d7e-4173-f056-6010" name="South Dakota 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0f19-43d5-1f31-5a74" name="South Dakota 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4acc-adf0-2711-89b8" name="South Dakota 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8777-9536-9df0-d726" name="South Dakota 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11947,6 +12112,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="00ef-2207-2c76-f7f9" name="Indiana" hidden="false" collective="false" import="true" type="model">
@@ -11960,11 +12126,13 @@
                 <selectionEntry id="0769-50d7-7543-45b0" name="Indiana" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="315f-5e9c-4725-9c8f" name="Indiana 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11972,6 +12140,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4f94-4b93-7482-a687" name="Massachusetts" hidden="false" collective="false" import="true" type="model">
@@ -11985,26 +12154,31 @@
                 <selectionEntry id="7f2f-dd35-aaec-876f" name="Massachusetts" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c89f-2bda-d96d-aa6a" name="Massachusetts 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f201-ee2e-fc97-03be" name="Massachusetts 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6d58-37f8-4099-aa5a" name="Massachusetts 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="21dd-cadb-250c-ad52" name="Massachusetts 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12012,6 +12186,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="54a1-6aed-bd74-b0d8" name="Alabama" hidden="false" collective="false" import="true" type="model">
@@ -12025,21 +12200,25 @@
                 <selectionEntry id="b2fc-c23c-a52c-3b12" name="Alabama" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3044-4ae2-9c5b-6629" name="Alabama 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="539a-fa97-bf1b-8588" name="Alabama 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a555-ecbc-8aae-90f3" name="Alabama 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12047,11 +12226,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="825.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="382b-c000-0b8e-c1d5" name="Tennessee-Class Battleship" hidden="false" collective="false" import="true" type="unit">
@@ -12071,16 +12252,19 @@
                 <selectionEntry id="6e22-e466-8013-ac9d" name="California" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2937-6243-78d9-35b2" name="California 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7170-e5e1-222b-0057" name="California 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="305.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12088,6 +12272,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5eed-b93c-3d31-2a75" name="Tennessee" hidden="false" collective="false" import="true" type="model">
@@ -12101,16 +12286,19 @@
                 <selectionEntry id="1d80-72eb-73b3-6a6c" name="Tennessee" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2093-e1e6-e649-59aa" name="Tennessee 1942 " hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="90.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ca61-887d-7950-3aef" name="Tennessee 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="240.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12118,11 +12306,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="400.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="707d-c524-82c0-6135" name="Wyoming-Class Battleship" hidden="false" collective="false" import="true" type="unit">
@@ -12142,21 +12332,25 @@
                 <selectionEntry id="2bec-b44d-cdfe-bfe8" name="Arkansas" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4a6e-1556-fd63-e7f3" name="Arkansas 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c0ff-6e6e-98f1-f828" name="Arkansas 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="75.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1bd7-1062-c5b1-636f" name="Arkansas 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="80.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12164,6 +12358,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="14a0-2708-0a64-cb64" name="Wyoming" hidden="false" collective="false" import="true" type="model">
@@ -12177,6 +12372,7 @@
                 <selectionEntry id="064e-f108-1af2-284a" name="Wyoming" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12184,11 +12380,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="250.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8c1c-96c2-88fa-8153" name="Bogue-Class Carrier" hidden="false" collective="false" import="true" type="unit">
@@ -12208,16 +12406,19 @@
                 <selectionEntry id="98ba-9b7e-7dfa-cc83" name="Altamaha" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ea77-3bdb-ced1-6580" name="Altamaha 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="69a9-71b9-5d5b-329a" name="Altamaha 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12225,6 +12426,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9e92-90a5-f3cc-0fa5" name="Barnes" hidden="false" collective="false" import="true" type="model">
@@ -12238,16 +12440,19 @@
                 <selectionEntry id="2f80-c19f-71ba-7e3a" name="Barnes" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="04de-c8dd-702d-fbcd" name="Barnes 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="797e-c0fc-c888-c989" name="Barnes 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12255,6 +12460,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0455-1b2d-22be-b01a" name="Block Island" hidden="false" collective="false" import="true" type="model">
@@ -12268,16 +12474,19 @@
                 <selectionEntry id="483c-4174-1a6a-56d9" name="Block Island" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="aebc-fbc9-09aa-700d" name="Block Island 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cc6d-e4aa-c5f4-ea78" name="Block Island 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12285,6 +12494,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dac5-9e69-f25f-ca6c" name="Bretan" hidden="false" collective="false" import="true" type="model">
@@ -12298,16 +12508,19 @@
                 <selectionEntry id="2fbe-e0c8-bd71-b12c" name="Bretan" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="969e-5fb9-9bd3-98ec" name="Bretan 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0d33-eb99-0c4f-ab89" name="Bretan 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12315,6 +12528,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="15ac-3a26-485a-93d8" name="Card" hidden="false" collective="false" import="true" type="model">
@@ -12328,16 +12542,19 @@
                 <selectionEntry id="0894-29c4-3934-3b6d" name="Card" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="22cd-468a-95f2-8f18" name="Card 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7cf1-846e-9e2c-976c" name="Card 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12345,6 +12562,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c478-77a9-0546-90b0" name="Copahee" hidden="false" collective="false" import="true" type="model">
@@ -12358,21 +12576,25 @@
                 <selectionEntry id="7421-394e-078c-4041" name="Copahee" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0e18-1305-fcca-ddf3" name="Copahee 1943a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e151-560a-8c19-df81" name="Copahee 1943b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5077-ea49-2396-2623" name="Copahee 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12380,6 +12602,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e569-332c-5795-2cc1" name="Core" hidden="false" collective="false" import="true" type="upgrade">
@@ -12393,16 +12616,19 @@
                 <selectionEntry id="a1b8-a7ff-e8ce-4d7c" name="Core" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="258f-b027-bed3-2a2d" name="Core 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c6a8-56a6-7017-bea2" name="Core 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12410,6 +12636,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="db80-6ffb-6dd1-53d4" name="Croatan" hidden="false" collective="false" import="true" type="model">
@@ -12423,21 +12650,25 @@
                 <selectionEntry id="3063-8c13-0c33-c0ca" name="Croatan" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="12bf-2d04-bfa3-65e9" name="Croatan 1943a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e0ad-66eb-07ef-41ad" name="Croatan 1943b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="11a2-3541-43ac-c1c8" name="Croatan 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12445,6 +12676,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5188-f918-05a5-8951" name="Nassau" hidden="false" collective="false" import="true" type="model">
@@ -12458,16 +12690,19 @@
                 <selectionEntry id="8919-1f3e-d5b2-1645" name="Nassau" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e948-b5de-fef9-b0f6" name="Nassau 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5d4e-7c07-d3ea-e9ea" name="Nassau 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12475,6 +12710,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b178-66b0-10b1-4c1a" name="Prince William" hidden="false" collective="false" import="true" type="model">
@@ -12488,26 +12724,31 @@
                 <selectionEntry id="5778-3a43-66f2-9eac" name="Prince William" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="82a6-e7d1-5c68-8a8a" name="Prince William 1943a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d1d4-b07e-b04a-f667" name="Prince William 1943b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4bca-a37d-b0b1-f1dd" name="Prince William 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="17ca-eb30-cca0-6c59" name="Prince William 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12515,6 +12756,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -12528,6 +12770,7 @@
       </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="100.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7ef3-faba-4074-4398" name="Casablanca-Class Carrier" hidden="false" collective="false" import="true" type="unit">
@@ -12547,11 +12790,13 @@
                 <selectionEntry id="8f95-f2d6-c923-c3a1" name="Admiralty Island" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4b89-dbf6-47af-ef4b" name="Admiralty Island 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12559,6 +12804,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e4cc-8b5c-87f6-e401" name="Attu" hidden="false" collective="false" import="true" type="model">
@@ -12572,11 +12818,13 @@
                 <selectionEntry id="3e78-973e-d420-ad1a" name="Attu" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3558-fedd-1354-bd24" name="Attu 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12584,6 +12832,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="992f-a300-3199-f52c" name="Bismark Sea" hidden="false" collective="false" import="true" type="model">
@@ -12597,6 +12846,7 @@
                 <selectionEntry id="faef-bd9f-9789-401a" name="Bismark Sea" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12604,6 +12854,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b041-783c-c6d9-390a" name="Bougainville" hidden="false" collective="false" import="true" type="model">
@@ -12617,11 +12868,13 @@
                 <selectionEntry id="cd47-8434-d733-5335" name="Bougainville" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3e4e-07b7-d8eb-6210" name="Bougainville 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12629,6 +12882,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3d57-d5cf-4d82-5efd" name="Cape Esperance" hidden="false" collective="false" import="true" type="model">
@@ -12642,11 +12896,13 @@
                 <selectionEntry id="b8c5-e47b-80ab-dc17" name="Cape Esperance" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2c01-0d16-74d6-988c" name="Cape Esperance 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12654,6 +12910,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8a50-3b88-33eb-b022" name="Casablanca" hidden="false" collective="false" import="true" type="model">
@@ -12667,11 +12924,13 @@
                 <selectionEntry id="6591-80e4-985f-e2fc" name="Casablanca" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5bf3-49ff-1e73-4e54" name="Casablanca 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12679,6 +12938,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c0ac-3e62-19c7-fa5f" name="Coral Sea" hidden="false" collective="false" import="true" type="model">
@@ -12692,11 +12952,13 @@
                 <selectionEntry id="354d-34f6-79fe-2ef9" name="Coral Sea" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cabe-edab-c9f0-fd94" name="Coral Sea 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12704,6 +12966,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cec7-f725-b76c-5a22" name="Corregidor" hidden="false" collective="false" import="true" type="model">
@@ -12717,11 +12980,13 @@
                 <selectionEntry id="032e-98e7-7bbb-36c9" name="Corregidor" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1578-c5ef-c6e4-db03" name="Corregidor 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12729,6 +12994,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0228-7589-01af-0645" name="Fanshaw Bay" hidden="false" collective="false" import="true" type="model">
@@ -12742,11 +13008,13 @@
                 <selectionEntry id="d7ea-a697-d5c4-6e24" name="Fanshaw Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="70ff-ce8a-04cf-ff5c" name="Fanshaw Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12754,6 +13022,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b433-4f5b-ca35-75a0" name="Gambier Bay" hidden="false" collective="false" import="true" type="model">
@@ -12767,6 +13036,7 @@
                 <selectionEntry id="ad8f-6859-2e15-0665" name="Gambier Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12774,6 +13044,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="341b-ca28-c20a-a3ce" name="Guadalcanal" hidden="false" collective="false" import="true" type="model">
@@ -12787,11 +13058,13 @@
                 <selectionEntry id="dd35-5854-7042-319b" name="Guadalcanal" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="45d9-ecd9-dcda-2caa" name="Guadalcanal 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12799,6 +13072,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b785-cc63-29de-a71b" name="Hoggatt Bay" hidden="false" collective="false" import="true" type="model">
@@ -12812,11 +13086,13 @@
                 <selectionEntry id="b7cd-dae3-df5d-1525" name="Hoggatt Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9b3c-14d6-f2dc-1c42" name="Hoggatt Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12824,6 +13100,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9db2-881f-000d-4196" name="Hollandia" hidden="false" collective="false" import="true" type="model">
@@ -12837,11 +13114,13 @@
                 <selectionEntry id="49dd-5e7f-3979-e5c7" name="Hollandia" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ac4c-a2d1-a423-7b22" name="Hollandia 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12849,6 +13128,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6975-7e0d-94d4-ef20" name="Kadashan Bay" hidden="false" collective="false" import="true" type="model">
@@ -12862,11 +13142,13 @@
                 <selectionEntry id="fc6d-0f90-e48c-c895" name="Kadashan Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9afe-f1c7-8810-b6aa" name="Kadashan Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12874,6 +13156,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6002-bb83-ff87-c881" name="Kalinin Bay" hidden="false" collective="false" import="true" type="model">
@@ -12887,6 +13170,7 @@
                 <selectionEntry id="f74a-ea4f-7cfe-0d87" name="Kalinin Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12894,6 +13178,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a04c-2f7d-b9ac-68ce" name="Kasaan Bay" hidden="false" collective="false" import="true" type="model">
@@ -12907,11 +13192,13 @@
                 <selectionEntry id="83f9-cc1d-2263-f285" name="Kasaan Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="872e-33ee-41d1-a9e0" name="Kasaan Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12919,6 +13206,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5bf5-3eb7-9c41-c8c6" name="Kitkun Bay" hidden="false" collective="false" import="true" type="model">
@@ -12932,11 +13220,13 @@
                 <selectionEntry id="55cf-0206-2602-f407" name="Kitkun Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2ebb-ea7a-58c3-dd74" name="Kitkun Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12944,6 +13234,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e80b-e349-6a7c-61ed" name="Kwajalein" hidden="false" collective="false" import="true" type="model">
@@ -12957,11 +13248,13 @@
                 <selectionEntry id="78e2-8638-fe19-1e9d" name="Kwajalein" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fb5c-1a98-dee1-414d" name="Kwajalein 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12969,6 +13262,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a10c-a06a-fcd2-e181" name="Liscombe Bay" hidden="false" collective="false" import="true" type="model">
@@ -12982,6 +13276,7 @@
                 <selectionEntry id="bee5-aab9-980f-daf7" name="Liscombe Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12989,6 +13284,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1afe-6746-fe1c-41a5" name="Lunga Point" hidden="false" collective="false" import="true" type="model">
@@ -13002,11 +13298,13 @@
                 <selectionEntry id="ce15-539f-52ff-4c3d" name="Lunga Point" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="20a6-6255-cebb-5786" name="Lunga Point 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13014,6 +13312,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cb85-35fe-0410-4548" name="Makassar-Stait" hidden="false" collective="false" import="true" type="model">
@@ -13027,11 +13326,13 @@
                 <selectionEntry id="7bd0-1f87-134c-8ed4" name="Makassar-Stait" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8607-06bf-8dad-cd90" name="Makassar-Stait 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13039,6 +13340,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4944-be48-9b81-11b3" name="Makin Island" hidden="false" collective="false" import="true" type="model">
@@ -13052,11 +13354,13 @@
                 <selectionEntry id="d97c-f129-ff2d-f3e1" name="Makin Island" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5617-5a86-d17a-c0b1" name="Makin Island 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13064,6 +13368,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6102-bd51-a80b-f6c3" name="Manila Bay" hidden="false" collective="false" import="true" type="model">
@@ -13077,11 +13382,13 @@
                 <selectionEntry id="4fc4-392b-8b59-bc26" name="Manila Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7408-6a65-1461-f395" name="Manila Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13089,6 +13396,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9e4d-e2b9-3620-6528" name="Marcus Island" hidden="false" collective="false" import="true" type="model">
@@ -13102,11 +13410,13 @@
                 <selectionEntry id="5178-23a7-8e4a-d305" name="Marcus Island" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f738-8f0d-0309-dfb2" name="Marcus Island 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13114,6 +13424,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7aa0-30eb-95a3-984c" name="Matanikau" hidden="false" collective="false" import="true" type="model">
@@ -13127,11 +13438,13 @@
                 <selectionEntry id="9470-68f6-17bf-a0ce" name="Matanikau" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6c09-114c-8f9d-903b" name="Matanikau 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13139,6 +13452,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3348-a518-4273-97a2" name="Mission Bay" hidden="false" collective="false" import="true" type="model">
@@ -13152,11 +13466,13 @@
                 <selectionEntry id="5c4e-f5b7-c967-3996" name="Mission Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dfce-b92b-88ae-d115" name="Mission Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13164,6 +13480,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4b80-b191-c7b0-e98d" name="Munda" hidden="false" collective="false" import="true" type="model">
@@ -13177,11 +13494,13 @@
                 <selectionEntry id="3809-ea2e-64f5-f451" name="Munda" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6ab5-e49d-bcea-20cd" name="Munda 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13189,6 +13508,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fd8b-a95f-6985-a015" name="Natoma Bay" hidden="false" collective="false" import="true" type="model">
@@ -13202,11 +13522,13 @@
                 <selectionEntry id="a086-956b-32ec-d3db" name="Natoma Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8bd6-ea71-57e8-d6c5" name="Natoma Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13214,6 +13536,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="52c5-a83a-f8c0-4e27" name="Nehenta Bay" hidden="false" collective="false" import="true" type="model">
@@ -13227,11 +13550,13 @@
                 <selectionEntry id="2bc4-0cd0-ccf7-222a" name="Nehenta Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="04ab-0e93-3fab-0906" name="Nehenta Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13239,6 +13564,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="47e9-c64b-c29b-f20e" name="Ommaney Bay" hidden="false" collective="false" import="true" type="model">
@@ -13252,6 +13578,7 @@
                 <selectionEntry id="8542-d4e7-b597-2bea" name="Ommaney Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13259,6 +13586,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4808-8365-1663-f85c" name="Petrof Bay" hidden="false" collective="false" import="true" type="model">
@@ -13272,11 +13600,13 @@
                 <selectionEntry id="11c3-bcb3-fe72-311f" name="Petrof Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="aee5-3047-4910-cc86" name="Petrof Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13284,6 +13614,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="65fc-4985-59ee-2882" name="Roi" hidden="false" collective="false" import="true" type="model">
@@ -13297,11 +13628,13 @@
                 <selectionEntry id="1183-90cf-0d98-5da3" name="Roi" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7c7a-d34e-0ca0-c508" name="Roi 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13309,6 +13642,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="113d-b2de-1d10-92ba" name="Rudyerd Bay" hidden="false" collective="false" import="true" type="model">
@@ -13322,11 +13656,13 @@
                 <selectionEntry id="397b-a815-5984-f29a" name="Rudyerd Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="48d2-4928-3aeb-8c93" name="Rudyerd Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13334,6 +13670,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="906c-e3b5-0b77-7518" name="Saginaw Bay" hidden="false" collective="false" import="true" type="model">
@@ -13347,11 +13684,13 @@
                 <selectionEntry id="1966-7fa8-b2b5-b826" name="Saginaw Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b0ab-d47c-5a8d-5c3a" name="Saginaw Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13359,6 +13698,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="510d-c4d8-03a0-83cd" name="Salamaua" hidden="false" collective="false" import="true" type="model">
@@ -13372,11 +13712,13 @@
                 <selectionEntry id="3984-a887-6912-5505" name="Salamaua" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2724-2313-1c50-5516" name="Salamaua 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13384,6 +13726,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="191e-3f72-f8d3-0f02" name="Sargent Bay" hidden="false" collective="false" import="true" type="model">
@@ -13397,11 +13740,13 @@
                 <selectionEntry id="a859-2d16-4a8c-47d5" name="Sargent Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7cd5-0cf6-f1f3-31b4" name="Sargent Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13409,6 +13754,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5ca7-c77a-9d56-26d5" name="Savo Island" hidden="false" collective="false" import="true" type="model">
@@ -13422,11 +13768,13 @@
                 <selectionEntry id="b5ea-513e-1faa-f42f" name="Savo Island" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1e4f-5611-f70b-03de" name="Savo Island 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13434,6 +13782,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="665e-861d-2139-1c52" name="Shamrock Bay" hidden="false" collective="false" import="true" type="model">
@@ -13447,11 +13796,13 @@
                 <selectionEntry id="d737-2403-e9e3-83d7" name="Shamrock Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="32a0-b195-00d3-ae6d" name="Shamrock Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13459,6 +13810,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a7ff-51c2-9981-947e" name="Shipley Bay" hidden="false" collective="false" import="true" type="model">
@@ -13472,11 +13824,13 @@
                 <selectionEntry id="21e7-c5ca-bf06-42ad" name="Shipley Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4bc1-36b3-74ee-d52c" name="Shipley Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13484,6 +13838,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="63fb-559b-e281-d0d1" name="Stikoh Bay" hidden="false" collective="false" import="true" type="model">
@@ -13497,11 +13852,13 @@
                 <selectionEntry id="7d6b-8a9f-ac0e-9a1f" name="Sitkoh Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9bff-be5b-ca7a-1ef6" name="Sitkoh Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13509,6 +13866,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f78a-d6d8-07af-d69f" name="Solomons" hidden="false" collective="false" import="true" type="model">
@@ -13522,11 +13880,13 @@
                 <selectionEntry id="8c19-3c30-9118-e745" name="Solomons" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9ccb-421e-53ee-e07e" name="Solomons 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13534,6 +13894,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="595a-e9f5-6a46-bd66" name="St Lo" hidden="false" collective="false" import="true" type="model">
@@ -13547,6 +13908,7 @@
                 <selectionEntry id="6bf3-b356-6769-14f4" name="St Lo" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13554,6 +13916,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e660-26ba-0778-a1f9" name="Steamer Bay" hidden="false" collective="false" import="true" type="model">
@@ -13567,11 +13930,13 @@
                 <selectionEntry id="c423-cd66-d9af-295b" name="Steamer Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="523c-daac-8816-109c" name="Steamer Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13579,6 +13944,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5377-7ddb-5e14-8af3" name="Takanis Bay" hidden="false" collective="false" import="true" type="model">
@@ -13592,11 +13958,13 @@
                 <selectionEntry id="2164-6596-85e9-d507" name="Takanis Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5721-ba1e-c004-76f3" name="Takanis Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13604,6 +13972,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8fe3-3f59-8ad4-f0fd" name="Thetis Bay" hidden="false" collective="false" import="true" type="model">
@@ -13617,11 +13986,13 @@
                 <selectionEntry id="68d0-7736-a7af-8763" name="Thetis Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ffb7-6840-224d-61ef" name="Thetis Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13629,6 +14000,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="91df-250e-41b3-9bbf" name="Tripoli" hidden="false" collective="false" import="true" type="model">
@@ -13642,11 +14014,13 @@
                 <selectionEntry id="25e2-e18a-48b8-9b01" name="Tripoli" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="aeae-d84e-0802-5df4" name="Tripoli 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13654,6 +14028,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6bca-d10c-5210-1a96" name="Tulagi" hidden="false" collective="false" import="true" type="model">
@@ -13667,11 +14042,13 @@
                 <selectionEntry id="ad98-7283-6cdb-d254" name="Tulagi" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c5b2-2f31-52f4-721c" name="Tulagi 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13679,6 +14056,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a59c-a3a9-6279-4e5f" name="Wake Island" hidden="false" collective="false" import="true" type="model">
@@ -13692,11 +14070,13 @@
                 <selectionEntry id="7e02-e1ac-fdef-9b9b" name="Wake Island" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f928-8fac-6df3-e9d3" name="Wake Island 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13704,6 +14084,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="abaf-1972-8851-3ff5" name="White Plains" hidden="false" collective="false" import="true" type="model">
@@ -13717,11 +14098,13 @@
                 <selectionEntry id="e6aa-40f4-8339-6925" name="White Plains" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c537-70df-1f53-abd9" name="White Plains 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13729,6 +14112,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3117-0553-4ec2-dd29" name="Wingham Bay" hidden="false" collective="false" import="true" type="model">
@@ -13742,11 +14126,13 @@
                 <selectionEntry id="e3aa-1d45-ef60-d93a" name="Wingham Bay" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0bc8-b14c-7988-7959" name="Wingham Bay 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13754,11 +14140,21 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <entryLinks>
+        <entryLink id="0613-4ab6-6cd7-d5d0" name="Carrier Flights" hidden="false" collective="false" import="true" targetId="df8d-b7fa-ee1b-5a91" type="selectionEntryGroup">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bca3-60ad-2ee8-34f1" type="max"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00a8-6b88-d380-e37a" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="95.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5d32-98e5-063a-92c5" name="Independance-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -13778,11 +14174,13 @@
                 <selectionEntry id="1900-44e6-e196-3f78" name="Bataan" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a69e-cd55-6eda-d796" name="Bataan 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13790,6 +14188,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="aa94-014b-f236-8d8f" name="Belleau Wood" hidden="false" collective="false" import="true" type="model">
@@ -13803,11 +14202,13 @@
                 <selectionEntry id="b78c-62d5-5a75-b025" name="Belleau Wood" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7820-6791-db5e-4c75" name="Belleau Wood 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13815,6 +14216,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4aa1-b7a0-d5c8-c647" name="Cabot" hidden="false" collective="false" import="true" type="model">
@@ -13828,11 +14230,13 @@
                 <selectionEntry id="7940-0d98-560c-d70f" name="Cabot" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9c2e-211d-2b26-4910" name="Cabot 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13840,6 +14244,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1b45-5810-8137-e6de" name="Cowpens" hidden="false" collective="false" import="true" type="model">
@@ -13853,11 +14258,13 @@
                 <selectionEntry id="8580-8ed1-00a0-adf4" name="Cowpens" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3516-c8cc-f956-0d4a" name="Cowpens 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13865,6 +14272,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a802-0ae8-0dd5-3f0d" name="Independance" hidden="false" collective="false" import="true" type="model">
@@ -13878,11 +14286,13 @@
                 <selectionEntry id="86cb-0306-f85b-554c" name="Independace" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8819-302b-b6c5-29f4" name="Independance 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13890,6 +14300,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c6e0-3363-7f9c-1cfa" name="Langley" hidden="false" collective="false" import="true" type="model">
@@ -13903,11 +14314,13 @@
                 <selectionEntry id="ecca-bded-4664-883f" name="Langley" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dd28-b315-6162-0269" name="Langley 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13915,6 +14328,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a17c-0d4a-3d68-f9c8" name="Monterey" hidden="false" collective="false" import="true" type="upgrade">
@@ -13928,11 +14342,13 @@
                 <selectionEntry id="a520-39bd-952c-c625" name="Monterey" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8eae-f739-d4d9-afd7" name="Monterey 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13940,6 +14356,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="de1a-661a-19b8-b4fa" name="Princeton" hidden="false" collective="false" import="true" type="upgrade">
@@ -13953,6 +14370,7 @@
                 <selectionEntry id="4c94-35b3-79bf-4e53" name="Princeton" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13960,6 +14378,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4028-18a1-6d92-9c3e" name="San Jacinto" hidden="false" collective="false" import="true" type="model">
@@ -13973,11 +14392,13 @@
                 <selectionEntry id="c381-7864-d11f-f52b" name="San Jacinto" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a4af-7943-b2ac-5a14" name="San Jacinto 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13985,6 +14406,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -13998,6 +14420,7 @@
       </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="105.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1a1d-6a91-4f7c-cae0" name="Lexington-Class Carrier" hidden="false" collective="false" import="true" type="unit">
@@ -14017,11 +14440,13 @@
                 <selectionEntry id="19e8-b895-4c76-fee4" name="Lexington" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="95f7-0dff-fc8b-0762" name="Lexington 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-50.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14029,6 +14454,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4156-1513-9487-0b75" name="Saratoga" hidden="false" collective="false" import="true" type="model">
@@ -14042,21 +14468,25 @@
                 <selectionEntry id="2440-7f5a-bf23-ef67" name="Saratoga" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4417-2692-1186-1eaa" name="Saratoga 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0f9c-acea-ea67-058b" name="Saratoga 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="de6c-54d4-780a-2da4" name="Saratoga 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="155.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14064,6 +14494,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -14077,6 +14508,7 @@
       </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="260.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5950-1d24-37aa-2e89" name="Long Island-Class Carrier" hidden="false" collective="false" import="true" type="unit">
@@ -14096,21 +14528,25 @@
                 <selectionEntry id="70d3-455e-d4fb-4ef5" name="Long Island" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6b55-bfaa-302a-2b97" name="Long Island 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9aa3-62df-c8a9-2b37" name="Long Island 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="db1c-ac38-6901-3a23" name="Long Island 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14118,6 +14554,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="30da-f4a4-2960-e3a3" name="HMS Archer" hidden="false" collective="false" import="true" type="model">
@@ -14131,21 +14568,25 @@
                 <selectionEntry id="9e6c-4f21-488a-999c" name="Archer" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c1b0-28bc-793b-fb86" name="Archer 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8df3-1598-dec7-85bb" name="Archer 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ad91-5993-09c2-0df0" name="Archer 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14153,6 +14594,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -14166,6 +14608,7 @@
       </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="75.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ccd0-61e9-b15e-5629" name="Midway-Class Carrier" hidden="false" collective="false" import="true" type="unit">
@@ -14185,6 +14628,7 @@
                 <selectionEntry id="0fe9-8318-fc58-820a" name="Midway" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14192,6 +14636,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f153-d5c1-33c9-3fd6" name="Franklin D. Roosevelt" hidden="false" collective="false" import="true" type="model">
@@ -14205,6 +14650,7 @@
                 <selectionEntry id="fb96-fa0b-b339-b689" name="Franklin D. Roosevelt" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14212,6 +14658,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0bd2-9e80-e9df-7d92" name="Coral Sea" hidden="false" collective="false" import="true" type="model">
@@ -14225,6 +14672,7 @@
                 <selectionEntry id="fe89-3669-4d65-c736" name="Coral Sea" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14232,6 +14680,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -14245,6 +14694,7 @@
       </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="450.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e599-8985-c5b6-7d00" name="Ranger-Class Carrier" hidden="false" collective="false" import="true" type="unit">
@@ -14264,26 +14714,31 @@
                 <selectionEntry id="2025-8db4-cda4-205b" name="Ranger" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fa8b-4261-9021-c4cb" name="Ranger 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1bdf-ae2b-3448-821c" name="Ranger 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="83ef-a382-78ea-9a25" name="Ranger 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c8f4-ffe8-dc77-2f91" name="Ranger 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14291,6 +14746,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -14304,6 +14760,7 @@
       </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="220.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="05d6-d7ca-855d-f1f3" name="Sangamon-Class Carrier" hidden="false" collective="false" import="true" type="unit">
@@ -14323,21 +14780,25 @@
                 <selectionEntry id="b557-cd3a-8fe2-ea8f" name="Chenango" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6fa9-8a04-8beb-f40c" name="Chenango 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="497c-8488-3260-f10b" name="Chenango 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="667f-1803-0ed5-d21f" name="Chenango 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14345,6 +14806,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="722e-d6d6-1071-5351" name="Sangamon" hidden="false" collective="false" import="true" type="model">
@@ -14358,21 +14820,25 @@
                 <selectionEntry id="8fa0-39a1-d222-c402" name="Sangamon" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="78ad-8290-7eab-8bfe" name="Sangamon 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8088-290f-c582-66d3" name="Sangamon 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a941-d8dc-ba22-520b" name="Sangamon 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14380,6 +14846,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9486-f885-c40d-e0fe" name="Santee" hidden="false" collective="false" import="true" type="model">
@@ -14393,21 +14860,25 @@
                 <selectionEntry id="6cc7-dbd7-2dd3-7b51" name="Santee" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e026-2296-2650-215a" name="Santee 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="df6c-d7c6-b983-557f" name="Santee 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="30b0-86e9-e7c6-1437" name="Santee 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14415,6 +14886,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="334d-bb23-3ecd-fcdf" name="Suwannee" hidden="false" collective="false" import="true" type="model">
@@ -14428,21 +14900,25 @@
                 <selectionEntry id="abd2-1c46-032d-7572" name="Suwannee" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d78a-3014-1046-de24" name="Suwannee 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="384e-0306-cb7c-f387" name="Suwannee 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fad3-7ba5-a914-f741" name="Suwannee 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14450,6 +14926,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -14463,6 +14940,7 @@
       </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="100.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d263-35e9-4a40-ec4f" name="Wasp-Class Carrier" hidden="false" collective="false" import="true" type="unit">
@@ -14482,11 +14960,13 @@
                 <selectionEntry id="0f5a-bbe9-e769-46ae" name="Wasp" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ac77-7c43-1896-4620" name="Wasp 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14494,6 +14974,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -14507,6 +14988,7 @@
       </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="240.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="30ac-cbee-2472-c257" name="Yorktown-Class Carrier" hidden="false" collective="false" import="true" type="unit">
@@ -14526,26 +15008,31 @@
                 <selectionEntry id="0258-faf3-d704-ef3f" name="Enterprise" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a8dc-872e-0a8f-7e71" name="Enterprise 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c718-7318-5522-4229" name="Enterprise 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3e0c-43b1-986f-d5ea" name="Enterprise 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="95.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ffac-d386-5e8c-71a7" name="Enterprise 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="105.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14553,6 +15040,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7017-9962-c1c2-12af" name="Hornet" hidden="false" collective="false" import="true" type="model">
@@ -14566,16 +15054,19 @@
                 <selectionEntry id="cb71-ec37-c828-6745" name="Hornet" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d99f-6be7-b675-088d" name="Hornet 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="932b-fdd0-e581-c0b5" name="Hornet 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14583,6 +15074,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ea21-8fcc-12a2-46d9" name="Yorktown" hidden="false" collective="false" import="true" type="model">
@@ -14596,16 +15088,19 @@
                 <selectionEntry id="56ed-122b-159b-13ca" name="Yorktown" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d04e-684a-401c-764a" name="Yorktown 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f388-a420-28fd-22b0" name="Yorktown 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14613,6 +15108,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -14626,6 +15122,7 @@
       </entryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="280.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0cd6-e183-1684-0577" name="Alaska-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -14645,6 +15142,7 @@
                 <selectionEntry id="5ebb-26ad-5364-5177" name="Alaska" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14652,6 +15150,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a6dc-2c89-febe-16e5" name="Guam" hidden="false" collective="false" import="true" type="model">
@@ -14665,6 +15164,7 @@
                 <selectionEntry id="2400-1352-333a-d7aa" name="Guam" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14672,11 +15172,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="250.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2249-87e8-b35d-eddd" name="Atlanta-Class Cruiser (Group 1)" hidden="false" collective="false" import="true" type="unit">
@@ -14696,6 +15198,7 @@
                 <selectionEntry id="a9ce-a0dd-e831-9579" name="Atlanta" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14703,6 +15206,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bc26-ab8b-6fd7-7ddb" name="Juneau" hidden="false" collective="false" import="true" type="model">
@@ -14716,6 +15220,7 @@
                 <selectionEntry id="8cca-a078-f0b5-5b6b" name="Juneau" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14723,6 +15228,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f1ec-813c-64f7-495a" name="San Diego" hidden="false" collective="false" import="true" type="model">
@@ -14736,16 +15242,19 @@
                 <selectionEntry id="1748-16c9-aee6-79f3" name="San Diego" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="64a8-0ce3-28bb-dc1c" name="San Diego 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ab5d-5e65-c8f9-c4be" name="San Diego 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14753,6 +15262,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5312-5ca1-9e23-9c9b" name="San Juan" hidden="false" collective="false" import="true" type="model">
@@ -14766,16 +15276,19 @@
                 <selectionEntry id="c2b7-0878-995d-04a1" name="San Juan" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7626-6caa-e86d-8842" name="San Juan 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="833f-8f52-c9d4-c769" name="San Juan 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14783,11 +15296,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="70.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dc13-84ee-3d6c-5d19" name="Atlanta-Class Cruiser (Group 2)" hidden="false" collective="false" import="true" type="unit">
@@ -14807,11 +15322,13 @@
                 <selectionEntry id="2b23-66a1-2020-8827" name="Oakland" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dc37-12f2-115a-439d" name="Oakland 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14819,6 +15336,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a132-6de4-07aa-ed32" name="Reno" hidden="false" collective="false" import="true" type="model">
@@ -14832,6 +15350,7 @@
                 <selectionEntry id="8f21-c53a-d54e-69d3" name="Reno" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14839,6 +15358,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b844-fcfd-fcf6-15aa" name="Flint" hidden="false" collective="false" import="true" type="model">
@@ -14852,6 +15372,7 @@
                 <selectionEntry id="0b40-1fd2-c6bc-fed3" name="Flint" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14859,6 +15380,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6cd7-164a-e4ed-2e07" name="Tucson" hidden="false" collective="false" import="true" type="model">
@@ -14872,11 +15394,13 @@
                 <selectionEntry id="d3f1-201d-4060-9de0" name="Tucson" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="df70-c45d-a275-e941" name="Tucson 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14884,6 +15408,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="462b-0920-629a-889a" name="Juneau" hidden="false" collective="false" import="true" type="model">
@@ -14897,6 +15422,7 @@
                 <selectionEntry id="f46f-4313-4f0f-e399" name="Juneau" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14904,6 +15430,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3326-7028-3ba7-71b5" name="Spokane" hidden="false" collective="false" import="true" type="model">
@@ -14917,6 +15444,7 @@
                 <selectionEntry id="6923-9b75-9d7f-c12a" name="Spokane" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14924,6 +15452,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0a21-c7f2-7caf-2cf3" name="Fresno" hidden="false" collective="false" import="true" type="model">
@@ -14937,6 +15466,7 @@
                 <selectionEntry id="4e93-28ea-3a53-4c50" name="Fresno" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14944,11 +15474,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="100.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1703-9d89-c3f5-0a78" name="Baltimore-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -14968,6 +15500,7 @@
                 <selectionEntry id="91d0-6d5b-a3bb-5244" name="Baltimore" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14975,6 +15508,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f4c8-b001-2d7e-78ea" name="Boston" hidden="false" collective="false" import="true" type="model">
@@ -14988,6 +15522,7 @@
                 <selectionEntry id="5d79-396d-777a-ccad" name="Boston" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -14995,6 +15530,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="50ad-71c9-961a-01d0" name="Bremerton" hidden="false" collective="false" import="true" type="model">
@@ -15008,11 +15544,13 @@
                 <selectionEntry id="ae98-10b4-095e-97a1" name="Bremerton" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e212-018b-4f68-0482" name="Bremerton 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15020,6 +15558,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d7cc-2b0b-1dc5-e61b" name="Canberra" hidden="false" collective="false" import="true" type="model">
@@ -15033,6 +15572,7 @@
                 <selectionEntry id="0cf5-ad15-9fb2-7c69" name="Canberra" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15040,6 +15580,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b6b6-8500-440a-a6d8" name="Chicago" hidden="false" collective="false" import="true" type="model">
@@ -15053,11 +15594,13 @@
                 <selectionEntry id="9f44-a124-b6c4-b136" name="Chicago" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="99ce-4cbe-d9e9-63d7" name="Chicago 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15065,6 +15608,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="30ea-f66a-7edf-b250" name="Columbus" hidden="false" collective="false" import="true" type="model">
@@ -15078,11 +15622,13 @@
                 <selectionEntry id="8422-2114-55ee-c49d" name="Columbus" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d8e5-ada1-4bf3-fb0c" name="Columbus 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15090,6 +15636,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="060d-dde9-386f-b1ae" name="Fall River" hidden="false" collective="false" import="true" type="model">
@@ -15103,11 +15650,13 @@
                 <selectionEntry id="00bb-bbd1-4899-4a6c" name="Fall River" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e0d4-1bd3-d769-2746" name="Fall River 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15115,6 +15664,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="28b4-5f66-1e93-495d" name="Helena" hidden="false" collective="false" import="true" type="model">
@@ -15128,11 +15678,13 @@
                 <selectionEntry id="1724-a29e-9b67-3349" name="Helena" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f729-687a-f547-7ca9" name="Helena 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15140,6 +15692,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ec39-2b79-a8bb-cfce" name="Los Angeles" hidden="false" collective="false" import="true" type="model">
@@ -15153,11 +15706,13 @@
                 <selectionEntry id="7928-a87b-3ced-52aa" name="Los Angeles" hidden="false" collective="false" import="true" type="model">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="789b-9875-f74f-191d" name="Los Angeles 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15165,6 +15720,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="380b-4cfd-3e2a-0467" name="Macon" hidden="false" collective="false" import="true" type="model">
@@ -15178,6 +15734,7 @@
                 <selectionEntry id="c8e9-d7c3-fc15-6550" name="Macon" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15185,6 +15742,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="eeb1-e71d-afe9-5864" name="Pittsburgh" hidden="false" collective="false" import="true" type="model">
@@ -15198,11 +15756,13 @@
                 <selectionEntry id="20f7-543a-4ca9-935c" name="Pittsburgh" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="60d0-c626-c423-62f0" name="Pittsburgh 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15210,6 +15770,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1093-00df-c58f-8fb9" name="Quincy" hidden="false" collective="false" import="true" type="model">
@@ -15223,6 +15784,7 @@
                 <selectionEntry id="02d7-3d2e-a480-9591" name="Quincy" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15230,6 +15792,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="20d6-9893-6527-70a5" name="St Paul" hidden="false" collective="false" import="true" type="model">
@@ -15243,11 +15806,13 @@
                 <selectionEntry id="e54f-1c6c-5a55-f169" name="St Paul" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="12e8-e06d-3273-3fb6" name="St Paul 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15255,11 +15820,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="150.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7ac2-716d-1122-b547" name="Brooklyn-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -15279,26 +15846,31 @@
                 <selectionEntry id="29d0-5ecb-5dba-da67" name="Brooklyn" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3870-993d-1366-7504" name="Brooklyn 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dc0c-9a2b-7175-319e" name="Brooklyn 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a790-2c61-64e6-ab75" name="Brooklyn 1944a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4ebd-cf63-9605-df48" name="Brooklyn 1944b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15306,6 +15878,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8aa2-6d48-7950-db13" name="Philadelphia" hidden="false" collective="false" import="true" type="model">
@@ -15319,26 +15892,31 @@
                 <selectionEntry id="3212-70c8-10bd-7ab6" name="Philadelphia" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cc46-a7f6-ca94-ac87" name="Philadelphia 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f92a-f367-5b07-f878" name="Philadelphia 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9454-cd32-3833-c061" name="Philadelphia 1944a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f32b-482a-50ac-22a6" name="Philadelphia 1944b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15346,6 +15924,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1ad7-8979-6a76-6189" name="Savannah" hidden="false" collective="false" import="true" type="model">
@@ -15359,31 +15938,37 @@
                 <selectionEntry id="71ae-d72c-d7fb-5268" name="Savannah" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6d78-b07f-b88a-a8cf" name="Savannah 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1b66-e185-1a71-1ee9" name="Savannah 1942a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="387f-0066-0a6f-f902" name="Savannah 1942b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bfda-f7a0-0e88-9de8" name="Savannah 1944a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4873-648b-7313-6689" name="Savannah 1944b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="50.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15391,6 +15976,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c53f-a6a5-aec8-d09f" name="Nashville" hidden="false" collective="false" import="true" type="model">
@@ -15404,26 +15990,31 @@
                 <selectionEntry id="60e3-bd11-16ba-d4f1" name="Nashville" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2fff-152b-bdfb-9cad" name="Nashville 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1a9e-2fe5-1f7c-318a" name="Nashville 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a7cc-decb-b711-d490" name="Nashville 1944a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bd40-6d2b-557d-e90d" name="Nashville 1944b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15431,6 +16022,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3aec-1334-12c3-fb1b" name="Phoenix" hidden="false" collective="false" import="true" type="model">
@@ -15444,21 +16036,25 @@
                 <selectionEntry id="80ef-dc38-2332-6cc4" name="Phoenix" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c86e-9a92-1174-7934" name="Phoenix 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="56bb-0f8f-a164-8214" name="Phoenix 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a53d-a082-a1b3-c2e1" name="Phoenix 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15466,6 +16062,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="db33-5a23-887b-5416" name="Boise" hidden="false" collective="false" import="true" type="model">
@@ -15479,21 +16076,25 @@
                 <selectionEntry id="9d71-ece5-21bd-340f" name="Boise" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2f3d-0cb8-c541-a297" name="Boise 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b709-df46-6bc4-386a" name="Boise 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9bb6-e305-f53c-81bb" name="Boise 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15501,6 +16102,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="faff-93fb-617f-4ac0" name="Honolulu" hidden="false" collective="false" import="true" type="model">
@@ -15514,26 +16116,31 @@
                 <selectionEntry id="1c6f-d831-294a-091d" name="Honolulu" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="44bb-b6d4-e2c5-3408" name="Honolulu 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fbf1-7d0d-146a-0efc" name="Honolulu 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d152-35ae-347d-ea93" name="Honolulu 1944a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0ea9-ea9d-046a-6525" name="Honolulu 1944b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15541,11 +16148,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="110.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="59ba-8b13-a1d4-bb75" name="Cleveland-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -15565,11 +16174,13 @@
                 <selectionEntry id="2425-9dff-3520-74a0" name="Atlanta" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="48c2-ce96-85d4-cabc" name="Atlanta 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15577,6 +16188,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="182f-ce04-4ad4-053e" name="Cleveland" hidden="false" collective="false" import="true" type="model">
@@ -15590,11 +16202,13 @@
                 <selectionEntry id="5f6c-6cb4-9393-da74" name="Cleveland" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="40a5-c4ed-915d-9f50" name="Cleveland 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15602,6 +16216,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1e3b-73f3-5614-2c20" name="Columbia" hidden="false" collective="false" import="true" type="model">
@@ -15615,11 +16230,13 @@
                 <selectionEntry id="6a28-b337-f258-61f4" name="Columbia" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6988-300c-283e-3b9e" name="Columbia 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15627,6 +16244,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="97f2-0975-a381-2166" name="Dayton" hidden="false" collective="false" import="true" type="model">
@@ -15640,11 +16258,13 @@
                 <selectionEntry id="4456-0ae2-369c-f00a" name="Dayton" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e5ca-9231-c869-fc19" name="Dayton 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15652,6 +16272,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4f48-7525-4009-9ca6" name="Denver" hidden="false" collective="false" import="true" type="model">
@@ -15665,11 +16286,13 @@
                 <selectionEntry id="539f-9051-a2b7-47ee" name="Denver" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="eb46-84af-e3cf-7e51" name="Denver 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15677,6 +16300,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e57c-1438-9f6f-559f" name="Santa Fe" hidden="false" collective="false" import="true" type="model">
@@ -15690,11 +16314,13 @@
                 <selectionEntry id="779d-58ff-475a-39da" name="Santa Fe" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ed2f-b24b-9ffd-ddbb" name="Santa Fe 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15702,6 +16328,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1d89-fb19-8435-4d46" name="Birmingham" hidden="false" collective="false" import="true" type="model">
@@ -15715,11 +16342,13 @@
                 <selectionEntry id="0acd-7235-1d25-240a" name="Birmingham" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="77b1-dbab-2cf1-bebb" name="Birmingham 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15727,6 +16356,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a60f-0dd7-199a-fcdb" name="Mobile" hidden="false" collective="false" import="true" type="model">
@@ -15740,11 +16370,13 @@
                 <selectionEntry id="7d8b-99fd-587f-290b" name="Mobile" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9a15-ca2d-fc75-d7e2" name="Mobile 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15752,6 +16384,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="85e6-0b98-265e-5ce5" name="Montpelier" hidden="false" collective="false" import="true" type="model">
@@ -15765,11 +16398,13 @@
                 <selectionEntry id="3c80-309d-3d54-56a1" name="Montpelier" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="92b2-3781-bd01-f72c" name="Montpelier 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15777,6 +16412,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="46c6-4116-2dd6-8876" name="Pasadena" hidden="false" collective="false" import="true" type="model">
@@ -15790,11 +16426,13 @@
                 <selectionEntry id="9681-0cb3-3039-61f5" name="Pasadena" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7533-d0ba-e4b2-301d" name="Pasadena 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="50.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15802,6 +16440,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3ab3-3110-a02a-f4c1" name="Springfield" hidden="false" collective="false" import="true" type="model">
@@ -15815,11 +16454,13 @@
                 <selectionEntry id="2bfc-2750-3628-1ab9" name="Springfield" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b31b-0a86-6431-a523" name="Springfield 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="50.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15827,6 +16468,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3949-4cc9-81bd-012e" name="Topeka" hidden="false" collective="false" import="true" type="model">
@@ -15840,16 +16482,19 @@
                 <selectionEntry id="3e3f-d4df-dab7-cebb" name="Topeka" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="02ae-ac8e-1e38-e6e3" name="Topeka 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="50.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bb33-4ef2-2394-a344" name="Topeka 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15857,6 +16502,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="02b4-d3dd-120a-466b" name="Bilaxi" hidden="false" collective="false" import="true" type="model">
@@ -15870,11 +16516,13 @@
                 <selectionEntry id="d07c-f2e3-4d56-f76f" name="Bilaxi" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b04a-f337-9cb5-7f7a" name="Bilaxi 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="50.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15882,6 +16530,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9e6a-08db-222b-adb3" name="Houston" hidden="false" collective="false" import="true" type="model">
@@ -15895,11 +16544,13 @@
                 <selectionEntry id="5be1-ac4e-633a-cdd4" name="Houston" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="af5c-c314-7531-0954" name="Houston 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="50.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15907,6 +16558,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e146-5d09-59f6-4af9" name="Providence" hidden="false" collective="false" import="true" type="model">
@@ -15920,11 +16572,13 @@
                 <selectionEntry id="233a-f4e8-5dcf-b1a2" name="Providence" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="98f4-1b03-19ec-521f" name="Providence 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15932,6 +16586,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0d13-f659-87c5-f344" name="Vicksburg" hidden="false" collective="false" import="true" type="model">
@@ -15945,11 +16600,13 @@
                 <selectionEntry id="84e6-422d-0ac2-8a3e" name="Vicksburg" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fe98-8217-c51e-c1f3" name="Vicksburg 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15957,6 +16614,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="47a7-a412-0dc5-37f2" name="Duluth" hidden="false" collective="false" import="true" type="model">
@@ -15970,11 +16628,13 @@
                 <selectionEntry id="1a67-a30b-fdec-d3ae" name="Duluth" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fd38-ae09-8c3f-4657" name="Duluth 144" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -15982,6 +16642,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1141-68d2-341a-f10b" name="Miami" hidden="false" collective="false" import="true" type="model">
@@ -15995,11 +16656,13 @@
                 <selectionEntry id="1d62-01ae-17d9-d9d2" name="Miami" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f9a0-93e7-917d-986b" name="Miami 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16007,6 +16670,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f7b3-3838-5adc-b8a0" name="Astoria" hidden="false" collective="false" import="true" type="model">
@@ -16020,11 +16684,13 @@
                 <selectionEntry id="f64a-69ea-f893-178b" name="Astoria" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c915-026b-c5de-62fd" name="Astoria 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16032,6 +16698,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="651b-36e7-0b4c-a115" name="Oklahoma City" hidden="false" collective="false" import="true" type="model">
@@ -16045,11 +16712,13 @@
                 <selectionEntry id="bb09-f57f-9c32-6f64" name="Oklahoma City" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c766-198e-6440-2218" name="Oklahoma City 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16057,6 +16726,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="00fc-a44a-e724-a472" name="Little Rock" hidden="false" collective="false" import="true" type="model">
@@ -16070,11 +16740,13 @@
                 <selectionEntry id="1932-0903-71b0-acf5" name="Little Rock" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6c98-9d3c-de29-51af" name="Little Rock 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16082,6 +16754,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9f2e-369d-397f-5fd9" name="Amsterdam" hidden="false" collective="false" import="true" type="model">
@@ -16095,11 +16768,13 @@
                 <selectionEntry id="4602-c02a-6d7b-8887" name="Amsterdam" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="67c8-5278-afef-a451" name="Amsterdam 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="50.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16107,6 +16782,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4af5-0bdc-804c-531d" name="Portsmouth" hidden="false" collective="false" import="true" type="model">
@@ -16120,11 +16796,13 @@
                 <selectionEntry id="9cb3-4ded-ba95-a8ef" name="Portsmouth" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dc6b-6762-1e83-db1c" name="Portsmouth 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="50.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16132,6 +16810,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8f09-07ff-1ba9-686a" name="Wilkes-Barre" hidden="false" collective="false" import="true" type="model">
@@ -16145,11 +16824,13 @@
                 <selectionEntry id="c993-d870-f0e4-630b" name="Wilkes-Barre" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7e96-5cdc-baef-b84c" name="Wilkes-Barre 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16157,11 +16838,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="100.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cf8a-2491-d1ce-73ad" name="Des Moines-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -16176,6 +16859,7 @@
           </constraints>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-20.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7515-122f-0ed9-5bdd" name="Des Moine" hidden="false" collective="false" import="true" type="model">
@@ -16189,6 +16873,7 @@
                 <selectionEntry id="6559-965c-b42e-7bec" name="Des Moine" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16196,6 +16881,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="78b6-7982-d8ac-8d41" name="Newport News" hidden="false" collective="false" import="true" type="model">
@@ -16209,6 +16895,7 @@
                 <selectionEntry id="c849-d572-b15e-c543" name="Newport News" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16216,6 +16903,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="75f2-d83d-91ef-74b4" name="Salem" hidden="false" collective="false" import="true" type="model">
@@ -16229,6 +16917,7 @@
                 <selectionEntry id="a09c-08ad-eae3-2a75" name="Salem" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16236,11 +16925,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="180.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6415-aa60-9147-1895" name="Fargo-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -16260,6 +16951,7 @@
                 <selectionEntry id="adcd-4bcd-8b4c-661a" name="Fargo" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16267,6 +16959,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="34d2-8040-a287-a538" name="Huntingdon" hidden="false" collective="false" import="true" type="model">
@@ -16280,6 +16973,7 @@
                 <selectionEntry id="1c75-c3b5-3ac3-de7e" name="Huntingdon" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16287,11 +16981,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="105.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6880-29e5-b1bc-73f1" name="New Orleans-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -16311,31 +17007,37 @@
                 <selectionEntry id="415b-74f2-404e-94eb" name="New Orleans" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d566-5f6b-db72-6117" name="New Orleans 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="91ed-4858-9235-b316" name="New Orleans 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="71cb-7d94-c01b-0748" name="New Orleans 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="65.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="900c-978f-f6d6-e841" name="new Orleans 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="70.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="71f0-9e05-0cc6-0888" name="New Orleans 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16343,6 +17045,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="357f-d90a-5475-b590" name="Astoria" hidden="false" collective="false" import="true" type="model">
@@ -16356,16 +17059,19 @@
                 <selectionEntry id="e37c-4ea5-9267-d878" name="Astoria" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="db48-09c7-2805-d786" name="Astoria 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9758-540a-e922-68f0" name="Astoria 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16373,6 +17079,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f0d8-f00e-e3dd-9ed3" name="Minneapolis" hidden="false" collective="false" import="true" type="model">
@@ -16386,31 +17093,37 @@
                 <selectionEntry id="fd31-2fa8-4004-05d4" name="Minneapolis" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5816-5914-dfbd-1071" name="Minneapolis 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a7ee-a8db-5cde-89be" name="Minneapolis 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5381-6e75-0939-6d5e" name="Minneapolis 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="65.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bbc7-8128-af81-5aac" name="Minneapolis 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="70.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="647d-a052-eb14-d6c8" name="Minneapolis 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16418,6 +17131,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="57dc-08f4-dbb5-489f" name="Tuscaloosa" hidden="false" collective="false" import="true" type="model">
@@ -16431,26 +17145,31 @@
                 <selectionEntry id="8562-813f-7234-9fef" name="Tuscaloosa" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="be58-1076-19aa-c911" name="Tuscaloosa 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e75c-bf89-ee3e-c44a" name="Tuscaloosa 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="65.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d22c-10c5-4dc3-e317" name="Tuscaloosa 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="70.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3e29-cdbe-4e28-38d6" name="Tuscaloosa 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16458,6 +17177,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e3c6-73bb-d4d8-a3fd" name="San Francisco" hidden="false" collective="false" import="true" type="model">
@@ -16471,26 +17191,31 @@
                 <selectionEntry id="4b4c-b9fe-7568-340e" name="San Francisco" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4e42-3b49-49e4-b1ef" name="San Francisco 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="00c3-3860-b826-d84c" name="San Francisco 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="65.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a2c5-192a-9f94-1d92" name="San Francisco 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="70.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e450-9bbb-a5f5-7d71" name="San Francisco 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16498,6 +17223,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5b63-2a93-34b5-5500" name="Quincy" hidden="false" collective="false" import="true" type="model">
@@ -16511,11 +17237,13 @@
                 <selectionEntry id="7426-3f60-ad9e-c295" name="Quincy 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="27da-e3bd-3164-1a30" name="Quincy " hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16523,6 +17251,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a76a-e813-580d-9d5b" name="Vincennes" hidden="false" collective="false" import="true" type="model">
@@ -16536,11 +17265,13 @@
                 <selectionEntry id="e94f-0266-143b-e04b" name="Vincennes" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9986-ffff-2820-0c08" name="Vincennes 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16548,11 +17279,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="150.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="25f7-5db2-4da7-039f" name="Northampton-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -16572,21 +17305,25 @@
                 <selectionEntry id="b7a9-3d35-bc39-2305" name="Augusta" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1437-f02a-ef04-4cad" name="Augusta 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e7b5-7878-ff21-8404" name="Augusta 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="343f-943e-e9f0-d743" name="Augusta 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16594,6 +17331,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ff6c-ecc8-b0b8-d40c" name="Chester" hidden="false" collective="false" import="true" type="model">
@@ -16607,26 +17345,31 @@
                 <selectionEntry id="3ee2-91d2-adef-3e8b" name="Chester" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9d1e-ef96-b2bb-ea75" name="Chester 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6a15-2482-e6d1-48f4" name="Chester 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3433-2ca8-c772-8fab" name="Chester 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0ebc-6e8f-aabe-4b4b" name="Chester 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16634,6 +17377,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b2cd-39bc-e5b0-8571" name="Chicago" hidden="false" collective="false" import="true" type="model">
@@ -16647,21 +17391,25 @@
                 <selectionEntry id="2e9d-b383-1f61-6263" name="Chicago" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7b97-6aff-c6a9-a33f" name="Chicago 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="62c3-5a23-a6ca-9c0a" name="Chicago 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9c3e-d76e-aadf-d70d" name="Chicago 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16669,6 +17417,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="06b3-9a32-4cdd-6421" name="Houston" hidden="false" collective="false" import="true" type="model">
@@ -16682,11 +17431,13 @@
                 <selectionEntry id="d6fd-02dd-4627-105d" name="Houston" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="00a8-8f14-b19e-201c" name="Houston 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16694,6 +17445,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3e8b-4ac5-7b57-2c5f" name="Louisville" hidden="false" collective="false" import="true" type="model">
@@ -16707,21 +17459,25 @@
                 <selectionEntry id="1348-a129-bcaf-095e" name="Louisville" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="79bc-b26f-4877-284d" name="Louisville 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b32b-b8d7-3680-eeb8" name="Louisville 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2239-b878-6abe-20ee" name="Louisville 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16729,6 +17485,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="da0f-56af-398d-94e1" name="Northampton" hidden="false" collective="false" import="true" type="model">
@@ -16742,21 +17499,25 @@
                 <selectionEntry id="8a4c-2b44-315a-8275" name="Northampton" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="71cb-9e87-cd05-a77c" name="Northampton 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ee0d-26d7-eabf-e334" name="Northampton 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b02d-49fa-39ed-bdd9" name="Northampton 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16764,11 +17525,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="130.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6cd6-c866-e1a0-5bab" name="Omaha-Class Cruiser" hidden="false" collective="false" import="true" type="upgrade">
@@ -16784,26 +17547,31 @@
                 <selectionEntry id="a4ce-450b-49aa-fd63" name="Cincinnati" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bc2a-8f05-1c4c-c6b6" name="Cincinnati 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b926-b1c6-6152-2703" name="Cincinnati 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a6fb-8f11-9426-7972" name="Cincinnati 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="300a-a4fb-0c85-4085" name="Cincinnati 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16811,6 +17579,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d690-ee46-3c2f-64bb" name="Concord" hidden="false" collective="false" import="true" type="upgrade">
@@ -16824,21 +17593,25 @@
                 <selectionEntry id="1452-ad60-41fc-6a94" name="Concord" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="74db-29db-207f-2987" name="Concord 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fb9e-a1d6-9a39-6873" name="Concord 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f1ea-c522-546d-7f6d" name="Concord 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16846,6 +17619,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="739f-32ae-74ac-60a9" name="Detroit" hidden="false" collective="false" import="true" type="model">
@@ -16859,26 +17633,31 @@
                 <selectionEntry id="f37e-0630-0e5f-392b" name="Detroit" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0ff7-ce64-40b8-fae1" name="Detroit 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a1a0-c28a-d9af-d3c6" name="Detroit 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1f94-f685-997f-b179" name="Detroit 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3ad5-faff-d606-fb27" name="Detroit 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16886,6 +17665,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d4f8-6937-6f66-a321" name="Omaha" hidden="false" collective="false" import="true" type="model">
@@ -16899,21 +17679,25 @@
                 <selectionEntry id="cde3-e7e3-f269-ce03" name="Omaha" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2528-4cb3-8d78-c230" name="Omaha 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e248-285e-369d-7f81" name="Omaha 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0e34-e170-abdd-c878" name="Omaha 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16921,6 +17705,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6317-3c1c-be33-2b9c" name="Marblehead" hidden="false" collective="false" import="true" type="upgrade">
@@ -16934,21 +17719,25 @@
                 <selectionEntry id="4a3a-9890-0e79-b7d6" name="Marblehead" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7479-56ef-bbbf-6ea3" name="Marblehead 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9d90-d158-b68a-fed4" name="Marblehead 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d0b5-fa34-d281-b4f0" name="Marblehead 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16956,6 +17745,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="feee-b55b-9836-05f9" name="Memphis" hidden="false" collective="false" import="true" type="model">
@@ -16969,26 +17759,31 @@
                 <selectionEntry id="fd7a-4823-774a-c90f" name="Memphis" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bdc5-d15c-6510-e5b2" name="Memphis 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="982f-4a97-932e-6c4a" name="Memphis 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6c5a-9522-e84f-17ac" name="Memphis 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4882-04e9-08c2-7617" name="Memphis 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -16996,6 +17791,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="909f-d3c7-de62-75f7" name="Milwaukee" hidden="false" collective="false" import="true" type="model">
@@ -17009,21 +17805,25 @@
                 <selectionEntry id="9dfa-2107-ec75-e80f" name="Milwaukee" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0613-77c5-bdda-7c66" name="Milwaukee 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4941-1c60-d816-aa51" name="Milwaukee 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="25a7-6e46-5b08-d5cc" name="Milwaukee 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17031,6 +17831,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0d5a-cb23-601e-76d0" name="Raleigh" hidden="false" collective="false" import="true" type="model">
@@ -17044,21 +17845,25 @@
                 <selectionEntry id="2098-b855-389c-9205" name="Raleigh" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f346-3c16-7085-c068" name="Raleigh 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b5b5-900d-3c77-e5be" name="Raleigh 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5934-94ca-119c-c33b" name="Raleigh 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17066,6 +17871,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4e4d-2ca3-b7c1-4b73" name="Richmond" hidden="false" collective="false" import="true" type="model">
@@ -17079,21 +17885,25 @@
                 <selectionEntry id="1084-2c6a-0df9-47ee" name="Richmond" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8fe2-3c5b-c814-a06e" name="Richmond 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bf42-1eee-1c4a-43cd" name="Richmond 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9b32-b4f3-c6f3-8432" name="Richmond 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17101,6 +17911,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="00ad-dce2-5f3d-6182" name="Trenton" hidden="false" collective="false" import="true" type="upgrade">
@@ -17114,21 +17925,25 @@
                 <selectionEntry id="19d6-4793-21e4-67b2" name="Trenton" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5d04-6e03-a796-6a8b" name="Trenton 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b212-4aa9-76ea-1e84" name="Trenton 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3a29-25bd-185a-aac8" name="Trenton 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17136,11 +17951,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="90.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3706-cbbc-ef4e-44e4" name="Oregon City-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -17160,6 +17977,7 @@
                 <selectionEntry id="bf99-306d-0add-ab7f" name="Oregon City" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17167,6 +17985,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b3dd-8401-e501-9bf4" name="Albany" hidden="false" collective="false" import="true" type="model">
@@ -17180,6 +17999,7 @@
                 <selectionEntry id="5e5c-e437-352c-3baa" name="Albany" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17187,6 +18007,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="78a3-5370-baa4-6dd0" name="Rochester" hidden="false" collective="false" import="true" type="model">
@@ -17200,6 +18021,7 @@
                 <selectionEntry id="5b76-b6d5-d5c4-a75f" name="Rochester" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17207,6 +18029,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fd8b-a302-917d-549d" name="Northampton" hidden="false" collective="false" import="true" type="model">
@@ -17220,6 +18043,7 @@
                 <selectionEntry id="256a-a9d6-7eea-10e0" name="Northampton" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17227,11 +18051,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="170.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="732c-593c-e110-f435" name="Pensacola-Class Cruiser" hidden="false" collective="false" import="true" type="unit">
@@ -17251,36 +18077,43 @@
                 <selectionEntry id="5038-c095-0a47-e8f8" name="Pensacola" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f894-6641-06d1-414a" name="Pensacola 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b4b8-76b0-f45b-4aba" name="Pensacola 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8ef5-7fa7-4b40-6a36" name="Pensacola 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="35.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e757-a551-f6d5-a153" name="Pensacola 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="746c-c8cd-b5a8-5a63" name="Pensacola 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a57f-07cf-3f8d-89cd" name="Pensacola 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="65.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17288,6 +18121,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7080-6665-e804-29d4" name="Salt Lake City" hidden="false" collective="false" import="true" type="model">
@@ -17301,26 +18135,31 @@
                 <selectionEntry id="1efd-c93d-f28a-907f" name="Salt Lake City" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cb86-2a8a-07ba-f708" name="Salt Lake City 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ec19-5975-22fe-769a" name="Salt Lake City 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dc74-6cfb-d32a-dcb8" name="Salt Lake City 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="29ee-0408-4ddf-1b37" name="Salt Lake City 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="45.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17328,11 +18167,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="125.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fbaa-fd6b-27b8-ef38" name="Clemson-Class Destroyer" hidden="false" collective="false" import="true" type="unit">
@@ -17352,6 +18193,7 @@
                 <selectionEntry id="a9af-5621-a266-66b5" name="Abel P. Upshur" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17359,6 +18201,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0af1-5d99-3df2-3ade" name="Aulick" hidden="false" collective="false" import="true" type="model">
@@ -17372,6 +18215,7 @@
                 <selectionEntry id="d927-78a0-6501-757e" name="Aulick" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17379,6 +18223,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5ac7-ab77-5182-dc71" name="Bailey" hidden="false" collective="false" import="true" type="model">
@@ -17392,6 +18237,7 @@
                 <selectionEntry id="8e18-7da0-38ef-0e31" name="Bailey" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17399,6 +18245,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ef4b-4d88-f515-1277" name="Bancroft" hidden="false" collective="false" import="true" type="model">
@@ -17412,6 +18259,7 @@
                 <selectionEntry id="0948-c664-c5c1-67ce" name="Bancroft" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17419,6 +18267,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7a6f-a167-d345-3211" name="Branch" hidden="false" collective="false" import="true" type="model">
@@ -17432,6 +18281,7 @@
                 <selectionEntry id="21b6-801c-a3b3-062d" name="Branch" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17439,6 +18289,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="29fb-9a94-4c56-fd33" name="Edwards" hidden="false" collective="false" import="true" type="model">
@@ -17452,6 +18303,7 @@
                 <selectionEntry id="af18-a2b8-aefd-50cf" name="Edwards" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17459,6 +18311,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9d12-2515-f845-a362" name="Herndon" hidden="false" collective="false" import="true" type="model">
@@ -17472,6 +18325,7 @@
                 <selectionEntry id="782d-0287-fc8b-3156" name="Herndon" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17479,6 +18333,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dcb3-c131-c24e-8ed7" name="Hunt" hidden="false" collective="false" import="true" type="model">
@@ -17492,6 +18347,7 @@
                 <selectionEntry id="99b3-ab7d-3d62-abb5" name="Hunt" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17499,6 +18355,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dad0-e3e8-89a4-2e8e" name="Laub" hidden="false" collective="false" import="true" type="model">
@@ -17512,6 +18369,7 @@
                 <selectionEntry id="ebc4-d336-f91b-8b78" name="Laub" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17519,6 +18377,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4ea9-852a-2141-ff90" name="Mason" hidden="false" collective="false" import="true" type="model">
@@ -17532,6 +18391,7 @@
                 <selectionEntry id="f843-89b1-4ca8-f3a6" name="Mason" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17539,6 +18399,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c95f-819c-2147-25bf" name="McCalla" hidden="false" collective="false" import="true" type="model">
@@ -17552,6 +18413,7 @@
                 <selectionEntry id="f418-9844-522b-a181" name="McCalla" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17559,6 +18421,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f6d9-d495-73f8-1a0d" name="McCook" hidden="false" collective="false" import="true" type="model">
@@ -17572,6 +18435,7 @@
                 <selectionEntry id="91e0-8477-06ac-c23d" name="McCook" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17579,6 +18443,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d3de-e5c6-f879-91da" name="McLanahan" hidden="false" collective="false" import="true" type="model">
@@ -17592,6 +18457,7 @@
                 <selectionEntry id="6670-3801-53fe-28c4" name="McLanahan" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17599,6 +18465,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5e6c-1f02-3b83-5dc6" name="Meade" hidden="false" collective="false" import="true" type="model">
@@ -17612,6 +18479,7 @@
                 <selectionEntry id="715f-59a6-e556-9efd" name="Meade" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17619,6 +18487,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d7b2-1899-c32e-bd25" name="Rodgers" hidden="false" collective="false" import="true" type="model">
@@ -17632,6 +18501,7 @@
                 <selectionEntry id="6d10-5b25-0d60-b637" name="Rodgers" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17639,6 +18509,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0b41-f6f5-040a-8369" name="Satterlee" hidden="false" collective="false" import="true" type="model">
@@ -17652,6 +18523,7 @@
                 <selectionEntry id="159a-c868-5a1d-686e" name="Satterlee" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17659,6 +18531,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6be3-1a0c-f4b2-7e00" name="Shubrick" hidden="false" collective="false" import="true" type="model">
@@ -17672,6 +18545,7 @@
                 <selectionEntry id="23b9-9268-76f2-b072" name="Shubrick" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17679,6 +18553,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="efbe-37fc-a649-2fde" name="Swasey" hidden="false" collective="false" import="true" type="model">
@@ -17692,6 +18567,7 @@
                 <selectionEntry id="53d6-2eac-cd11-ed9e" name="Swasey" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17699,6 +18575,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e9dd-16d6-fe00-2c38" name="Welborn C. Wood" hidden="false" collective="false" import="true" type="model">
@@ -17712,6 +18589,7 @@
                 <selectionEntry id="4893-3175-6f34-f966" name="Welborn C. Wood" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17719,6 +18597,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="325f-b7d9-fa74-e871" name="Alden" hidden="false" collective="false" import="true" type="model">
@@ -17732,11 +18611,13 @@
                 <selectionEntry id="3f36-f680-6ccd-a53b" name="Alden" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="879e-3ee5-1109-a59c" name="Alden 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17744,6 +18625,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="25bd-d656-e992-2998" name="Barker" hidden="false" collective="false" import="true" type="model">
@@ -17757,11 +18639,13 @@
                 <selectionEntry id="7cbb-bd9f-8071-4904" name="Barker" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="646b-0753-2120-c6bc" name="Barker 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17769,6 +18653,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d33e-008b-a36c-02f9" name="Borie" hidden="false" collective="false" import="true" type="model">
@@ -17782,11 +18667,13 @@
                 <selectionEntry id="2a16-8761-c1e1-22c0" name="Borie" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9bff-3f32-00ca-bd49" name="Borie 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17794,6 +18681,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e07a-1a1c-8967-c944" name="Bulmer" hidden="false" collective="false" import="true" type="model">
@@ -17807,11 +18695,13 @@
                 <selectionEntry id="a56f-505c-9d1a-3aed" name="Bulmer" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2230-bdf5-fc49-12ae" name="Bulmer 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17819,6 +18709,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6684-0573-fe58-e6e4" name="John D. Edwards" hidden="false" collective="false" import="true" type="model">
@@ -17832,11 +18723,13 @@
                 <selectionEntry id="ab5c-ca40-33ee-520a" name="John D. Edwards" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9583-4990-de98-2ed5" name="John D. Edwards 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17844,6 +18737,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0164-9e27-b8b9-ecbd" name="John D. Ford" hidden="false" collective="false" import="true" type="model">
@@ -17857,11 +18751,13 @@
                 <selectionEntry id="e90a-4b46-3de9-4896" name="John D. Ford" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c0ee-d273-134f-a65a" name="John D. Ford 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17869,6 +18765,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b6cb-6e7f-dc1e-ce49" name="Parrott" hidden="false" collective="false" import="true" type="model">
@@ -17882,11 +18779,13 @@
                 <selectionEntry id="f53d-92a7-5b33-8614" name="Parrott" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4bdf-5bf7-494c-fbd6" name="Parrott 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17894,6 +18793,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bc4b-5653-a76a-94e4" name="Paul Jones" hidden="false" collective="false" import="true" type="model">
@@ -17907,11 +18807,13 @@
                 <selectionEntry id="43dc-fe0c-df64-4c67" name="Paul Jones" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ea1a-458c-3bce-80ed" name="Paul Jones 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17919,6 +18821,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2a88-1618-2c6e-8c69" name="Whipple" hidden="false" collective="false" import="true" type="model">
@@ -17932,11 +18835,13 @@
                 <selectionEntry id="7d10-1818-1070-ab17" name="Whipple" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="465a-792f-7331-ee22" name="Whipple 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17944,6 +18849,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e821-44d7-24dd-3966" name="Bainbridge" hidden="false" collective="false" import="true" type="model">
@@ -17957,21 +18863,25 @@
                 <selectionEntry id="ae32-8c74-c520-2460" name="Bainbridge " hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="83ca-2be4-717d-4a98" name="Bainbridge 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8c53-a459-8fc2-4f92" name="Bainbridge 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="20da-c8b5-ec19-e760" name="Bainbridge 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -17979,6 +18889,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fee4-48eb-5b7e-379d" name="Decatur" hidden="false" collective="false" import="true" type="model">
@@ -17992,21 +18903,25 @@
                 <selectionEntry id="a691-0acb-51e7-5d41" name="Decatur" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c9c8-7093-380a-c236" name="Decatur 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e5db-697e-140d-fd6f" name="Decatur 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4e7e-07cb-2225-93ed" name="Decator 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18014,6 +18929,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9aed-7030-b0f8-36c4" name="Broome" hidden="false" collective="false" import="true" type="model">
@@ -18027,16 +18943,19 @@
                 <selectionEntry id="103a-1226-99ee-4991" name="Broome" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5c22-385e-83bc-c0a1" name="Broome 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="574f-5043-bdfc-b57b" name="Broome 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18044,6 +18963,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7588-cd92-4fbf-dcd1" name="Dallas" hidden="false" collective="false" import="true" type="model">
@@ -18057,16 +18977,19 @@
                 <selectionEntry id="450a-5092-046e-1957" name="Dallas" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8af2-e8b3-7dca-3819" name="Dallas 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a29c-afa7-3328-d7f8" name="Dallas 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18074,6 +18997,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d582-1577-df93-3cb2" name="Ballard" hidden="false" collective="false" import="true" type="model">
@@ -18087,16 +19011,19 @@
                 <selectionEntry id="99ba-342c-f312-f05b" name="Ballard" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5295-c063-2a8a-9304" name="Ballard 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0cb4-2e1e-6c68-7619" name="Ballard 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18104,6 +19031,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a2e2-1318-0c7a-e799" name="Gillis" hidden="false" collective="false" import="true" type="model">
@@ -18117,16 +19045,19 @@
                 <selectionEntry id="d203-3776-c940-32e6" name="Gillis" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3c5a-4112-c601-9a62" name="Gillis 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="67c8-5ab0-6418-2a52" name="Gillis 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18134,6 +19065,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d145-23c7-711b-8c8e" name="Barry" hidden="false" collective="false" import="true" type="model">
@@ -18147,16 +19079,19 @@
                 <selectionEntry id="8f0b-d3fe-d3a2-0186" name="Barry" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ab3e-2204-02d5-62b4" name="Barry 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d7c7-485b-ace8-8872" name="Barry 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18164,6 +19099,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="58c2-2362-71ff-94dd" name="Balknap" hidden="false" collective="false" import="true" type="model">
@@ -18177,21 +19113,25 @@
                 <selectionEntry id="2c03-4893-4b2c-e139" name="Belknap" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4c87-477f-506f-836b" name="Belknap 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c025-e818-6a2c-c4fc" name="Belknap 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7c2b-0002-c503-9713" name="Belknap 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18199,6 +19139,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="434b-3bdb-bdea-4fcd" name="Brooks" hidden="false" collective="false" import="true" type="model">
@@ -18212,11 +19153,13 @@
                 <selectionEntry id="5534-3b84-2e48-3514" name="Brooks" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a476-8da4-f1c6-6769" name="Brooks 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18224,6 +19167,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1ec2-4641-2172-77da" name="Gilmer" hidden="false" collective="false" import="true" type="model">
@@ -18237,11 +19181,13 @@
                 <selectionEntry id="4cd6-cd0d-8147-9ac6" name="Gilmer" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ad87-6d92-eed5-b8ac" name="Gilmer 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18249,6 +19195,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="baa4-eb0f-4975-1dff" name="Humphreys" hidden="false" collective="false" import="true" type="model">
@@ -18262,11 +19209,13 @@
                 <selectionEntry id="4637-9d67-c239-c8ec" name="Humphreys" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5eda-aaff-d55b-d741" name="Humphreys 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18274,6 +19223,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8b3d-1f52-608c-a7c7" name="Sands" hidden="false" collective="false" import="true" type="model">
@@ -18287,11 +19237,13 @@
                 <selectionEntry id="ce08-e177-2733-afd3" name="Sands" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="abde-7c07-33d7-5118" name="Sands 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18299,6 +19251,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="64e7-b24a-073e-e605" name="Chandler" hidden="false" collective="false" import="true" type="model">
@@ -18312,16 +19265,19 @@
                 <selectionEntry id="9efe-e57a-d4cb-8795" name="Chandler" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0023-2552-a3f0-fec3" name="Chandler 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="024d-569e-ab1f-5756" name="Chandler 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18329,6 +19285,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5b8c-5aa6-4dbe-ac96" name="Childs" hidden="false" collective="false" import="true" type="model">
@@ -18342,16 +19299,19 @@
                 <selectionEntry id="920c-97eb-f57f-ec76" name="Childs" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f58d-7b10-5333-8b3c" name="Childs 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bd74-0825-b1fa-ea9b" name="Childs 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18359,6 +19319,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2655-bfb6-073d-cbc9" name="William B. Preston" hidden="false" collective="false" import="true" type="model">
@@ -18372,16 +19333,19 @@
                 <selectionEntry id="ba67-56f2-693d-11cc" name="William B. Preston" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="796c-42d8-db7a-a05f" name="William B. Preston 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="288f-0b7d-2a03-55cf" name="William B. Preston 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18389,6 +19353,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0578-d3d4-ede1-6925" name="Williamson" hidden="false" collective="false" import="true" type="model">
@@ -18402,16 +19367,19 @@
                 <selectionEntry id="6a02-c12d-ba25-83ed" name="Williamson" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d51e-999c-4793-bfc6" name="Williamson 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="72f9-ef1a-48df-6a4e" name="Williamson 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18419,6 +19387,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c4fb-21e3-37ec-c083" name="Clemson" hidden="false" collective="false" import="true" type="model">
@@ -18432,21 +19401,25 @@
                 <selectionEntry id="c189-6c62-63b3-7b56" name="Clemson" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="528f-7d73-f5e7-f0a2" name="Clemson 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0c78-f690-abfe-2051" name="Clemson 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0f45-d9c6-41c3-38b7" name="Clemson 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18454,6 +19427,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="eb8e-7b71-7896-0fb7" name="Dahlgren" hidden="false" collective="false" import="true" type="model">
@@ -18467,11 +19441,13 @@
                 <selectionEntry id="f7e7-49e5-5b1f-e6d0" name="Dahlgren" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d8d6-9077-5bb4-c7fc" name="Dahlgren 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18479,6 +19455,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f6fe-1e28-8fc5-a764" name="Fox" hidden="false" collective="false" import="true" type="model">
@@ -18492,11 +19469,13 @@
                 <selectionEntry id="040d-695f-4d61-0577" name="Fox" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f789-adf0-c370-6358" name="Fox 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18504,6 +19483,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="eb53-e30f-08ea-2956" name="Goff" hidden="false" collective="false" import="true" type="model">
@@ -18517,11 +19497,13 @@
                 <selectionEntry id="9559-a056-8b75-4c4b" name="Goff" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a823-775e-3cf8-1a30" name="Goff 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18529,6 +19511,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cb69-d4ba-e8c0-7de5" name="Hatfield" hidden="false" collective="false" import="true" type="model">
@@ -18542,11 +19525,13 @@
                 <selectionEntry id="9aa1-d13b-c22a-039e" name="Hatfield" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="de81-34e8-ddf9-72b2" name="Hatfield 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18554,6 +19539,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1c3b-16e0-1def-41ce" name="King" hidden="false" collective="false" import="true" type="model">
@@ -18567,11 +19553,13 @@
                 <selectionEntry id="b35f-80ad-8654-05a4" name="King" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c290-0bad-637e-d1d4" name="King 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18579,6 +19567,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e9e3-2e08-c041-ff56" name="Lawrence" hidden="false" collective="false" import="true" type="model">
@@ -18592,11 +19581,13 @@
                 <selectionEntry id="843c-c0a2-d4c2-1fd1" name="Lawrence 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bbfc-4d82-ebe5-80e9" name="Lawrence" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18604,6 +19595,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4473-731a-198c-55d8" name="Litchfield" hidden="false" collective="false" import="true" type="model">
@@ -18617,11 +19609,13 @@
                 <selectionEntry id="744b-49c3-6ae0-f87e" name="Litchfield" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cec1-a6c6-2c76-1e8d" name="Litchfield 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18629,6 +19623,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="96db-b5b7-5bcc-c7cb" name="George E. Badger" hidden="false" collective="false" import="true" type="model">
@@ -18642,21 +19637,25 @@
                 <selectionEntry id="fc35-8aeb-0aa4-66ab" name="George E. Badger" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c670-c0c1-0504-5fd2" name="George E. Badger 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dc23-72d5-b59f-105e" name="George E. Badger 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="acd7-2625-bc66-fa67" name="George E. Badger 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18664,6 +19663,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c7a3-e1e2-ae81-8405" name="Goldsborough" hidden="false" collective="false" import="true" type="model">
@@ -18677,21 +19677,25 @@
                 <selectionEntry id="0606-d7e2-ed4a-25f8" name="Goldsborough" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2539-6bca-fa81-b77b" name="Goldsborough 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bf4d-3de3-0809-4aba" name="Goldsborough 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a1dd-503c-eef5-43e9" name="Goldsborough 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18699,6 +19703,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f53f-0885-8595-2d8e" name="Greene" hidden="false" collective="false" import="true" type="model">
@@ -18712,21 +19717,25 @@
                 <selectionEntry id="06db-00f0-0873-5c0d" name="Greene" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3675-e794-4003-50b7" name="Greene 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ff88-f35e-8753-7c02" name="Greene 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0ddb-297a-739f-b195" name="Greene 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18734,6 +19743,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="20cc-197c-d166-8c68" name="Hopkins" hidden="false" collective="false" import="true" type="model">
@@ -18747,16 +19757,19 @@
                 <selectionEntry id="c942-5eed-3192-71db" name="Hopkins" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0733-387d-5b93-fa2b" name="Hopkins 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dc5a-7d65-8b0e-c2d0" name="Hopkins 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18764,6 +19777,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="60e7-25e9-8ff3-f1cc" name="Hovey" hidden="false" collective="false" import="true" type="model">
@@ -18777,16 +19791,19 @@
                 <selectionEntry id="1abc-1ea7-27ac-3357" name="Hovey" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1c0f-959c-19cc-45e2" name="Hovey 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="299e-b9d2-0485-e6a5" name="Hovey 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18794,6 +19811,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4794-00c4-e824-b7e4" name="Perry" hidden="false" collective="false" import="true" type="model">
@@ -18807,11 +19825,13 @@
                 <selectionEntry id="6d22-8f2c-f6a2-61d5" name="Perry" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2c9d-58d8-2b22-2d68" name="Perry 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18819,6 +19839,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7050-731b-dd7f-45f5" name="Southard" hidden="false" collective="false" import="true" type="model">
@@ -18832,16 +19853,19 @@
                 <selectionEntry id="bf3f-8d29-0429-5e54" name="Southard" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5cb0-7358-5f58-3d50" name="Southard 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0009-2ffa-7cff-e150" name="Southard 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18849,6 +19873,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ec6a-19d7-8310-b8c8" name="Trever" hidden="false" collective="false" import="true" type="model">
@@ -18862,16 +19887,19 @@
                 <selectionEntry id="1aee-5dcc-beb7-d20e" name="Trever" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="66be-d3a6-3c25-f887" name="Trever 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9548-0d98-db6a-a028" name="Trever 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18879,6 +19907,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="159a-711d-cf41-30d7" name="Hulbert" hidden="false" collective="false" import="true" type="upgrade">
@@ -18892,16 +19921,19 @@
                 <selectionEntry id="aadb-cfec-fab9-7bd5" name="Hulbert" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dea1-5f2e-5ad6-19f7" name="Hulbert 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1577-d746-1e74-9d19" name="Hulbert 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18909,6 +19941,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8bdc-a1f5-57eb-86c7" name="Kane" hidden="false" collective="false" import="true" type="model">
@@ -18922,16 +19955,19 @@
                 <selectionEntry id="97ea-038b-0369-f610" name="Kane" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="897b-dcd7-883e-f9f8" name="Kane 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2973-a075-b877-e0cc" name="Kane 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18939,6 +19975,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d790-e984-7bd0-6f44" name="Long" hidden="false" collective="false" import="true" type="model">
@@ -18952,16 +19989,19 @@
                 <selectionEntry id="060c-07ad-09c2-c1cb" name="Long" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2a2b-6aad-422b-8547" name="Long 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="01cb-37cd-14b5-d5c9" name="Long 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -18969,6 +20009,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6e7f-68d2-9118-d7ac" name="MacLeish" hidden="false" collective="false" import="true" type="model">
@@ -18982,21 +20023,25 @@
                 <selectionEntry id="d03d-8610-4013-d6d7" name="MacLeish" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d821-5d40-0f38-1eac" name="MacLeish 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6e18-ad58-6cbc-ef3c" name="MacLeish 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2617-0e5d-8ac2-b025" name="MacLeish 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19004,6 +20049,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a607-c9d7-3cce-254a" name="Simpson" hidden="false" collective="false" import="true" type="model">
@@ -19017,21 +20063,25 @@
                 <selectionEntry id="a43c-a1df-5869-7c49" name="Simpson" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a5b1-c714-3269-0cb0" name="Simpson 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9677-3f47-b821-489d" name="Simpson 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ba87-5f9f-02e9-3121" name="Simpson 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19039,6 +20089,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e84d-6a4f-b9b5-ca12" name="McCormick" hidden="false" collective="false" import="true" type="model">
@@ -19052,21 +20103,25 @@
                 <selectionEntry id="15fc-4383-3b3e-8d20" name="McCormick" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3ace-8057-756a-aa1d" name="McCormick 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c3fe-6bb2-a7f7-654f" name="McCormick 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5b5d-5ef0-b55a-7707" name="McCormick 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19074,6 +20129,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7d6d-220f-b057-bd4b" name="Noa" hidden="false" collective="false" import="true" type="model">
@@ -19087,11 +20143,13 @@
                 <selectionEntry id="2709-3213-b60c-83cf" name="Noa" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a995-8e22-95d9-b69e" name="Noa 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19099,6 +20157,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f0e4-01e1-b4a3-5458" name="Osmond Ingram" hidden="false" collective="false" import="true" type="model">
@@ -19112,16 +20171,19 @@
                 <selectionEntry id="9dc0-2419-9666-9fc7" name="Osmond Ingram" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9aad-a78f-e415-5d7b" name="Osmond Ingram 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b3f0-4f4a-f9ba-b033" name="Osmond Ingram 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19129,6 +20191,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="952b-47f2-916a-fe00" name="Overton" hidden="false" collective="false" import="true" type="model">
@@ -19142,21 +20205,25 @@
                 <selectionEntry id="53eb-8f6f-782a-e4e5" name="Overton" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="397e-b923-328e-46ae" name="Overton 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="29a5-a20b-41e7-4c8a" name="Overton 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="189a-6dda-8786-533c" name="Overton 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19164,6 +20231,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="81b4-0114-3771-4bf7" name="Preble" hidden="false" collective="false" import="true" type="model">
@@ -19177,16 +20245,19 @@
                 <selectionEntry id="3e46-137c-ef0b-63bf" name="Preble" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4477-4204-a58c-721f" name="Preble 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7a27-6f33-f523-b09d" name="Preble 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19194,6 +20265,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="09a4-b8bb-daf1-3388" name="Pruitt" hidden="false" collective="false" import="true" type="model">
@@ -19207,16 +20279,19 @@
                 <selectionEntry id="1743-248f-bf4c-bf78" name="Pruitt" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cb70-f859-4543-8767" name="Pruitt 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3bc7-e1a3-2ab7-0384" name="Pruitt 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19224,6 +20299,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6507-a4b2-6a30-c806" name="Sicard" hidden="false" collective="false" import="true" type="model">
@@ -19237,16 +20313,19 @@
                 <selectionEntry id="d829-c333-deb3-1b15" name="Sicard" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fad1-23c4-fecc-7d3e" name="Sicard 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a7c5-6fc3-b73e-7bd1" name="Sicard 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19254,6 +20333,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="de25-6de5-74c5-c23a" name="Tracy" hidden="false" collective="false" import="true" type="model">
@@ -19267,16 +20347,19 @@
                 <selectionEntry id="285c-b7a7-1b2d-04e2" name="Tracy" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="16f6-0b23-c5b6-560a" name="Tracy 1939" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dc84-42e5-238a-027e" name="Tracy 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19284,6 +20367,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="17ee-1439-6eca-70dc" name="Reuben James" hidden="false" collective="false" import="true" type="model">
@@ -19297,16 +20381,19 @@
                 <selectionEntry id="761a-b387-6d81-f27c" name="Reuben James" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0f5d-d835-9528-a092" name="Reuben James 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2fc9-d420-275a-26d1" name="Reuben James 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19314,6 +20401,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7349-4ffd-fead-ea31" name="Truxtun" hidden="false" collective="false" import="true" type="model">
@@ -19327,16 +20415,19 @@
                 <selectionEntry id="767a-3ab0-ed04-1c97" name="Truxtun" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3d10-4bb5-6823-6254" name="Truxtun 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a084-50f2-0c30-16ea" name="Truxtun 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19344,6 +20435,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="37d7-4c93-5191-31c1" name="Thornton" hidden="false" collective="false" import="true" type="model">
@@ -19357,16 +20449,19 @@
                 <selectionEntry id="570c-84bc-8d9b-497c" name="Thornton" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6020-9807-0c06-4c2b" name="Thornton 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="879b-ce35-5765-5d41" name="Thornton 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19374,6 +20469,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9be2-4e1f-94c3-7397" name="Wasmuth" hidden="false" collective="false" import="true" type="model">
@@ -19387,11 +20483,13 @@
                 <selectionEntry id="8e4f-9c36-8011-ef9b" name="Wasmuth" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2cb1-7d06-b8d7-cf86" name="Wasmuth 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19399,6 +20497,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fa73-595f-8e3d-69c4" name="Zane" hidden="false" collective="false" import="true" type="model">
@@ -19412,16 +20511,19 @@
                 <selectionEntry id="2574-6b5c-31bc-c649" name="Zane" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4522-75d7-4b4f-3ca4" name="Zane 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a5f5-0208-b26f-40c5" name="Zane 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19429,6 +20531,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9e2e-dc75-3700-8503" name="Edsall" hidden="false" collective="false" import="true" type="model">
@@ -19442,6 +20545,7 @@
                 <selectionEntry id="d6e8-eea5-f680-0c52" name="Edsall" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19449,6 +20553,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c9ef-82fd-502d-adda" name="Pillsbury" hidden="false" collective="false" import="true" type="model">
@@ -19462,6 +20567,7 @@
                 <selectionEntry id="0657-d68e-4d6b-2e97" name="Pillsbury" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19469,6 +20575,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="72e9-7830-a2c1-511c" name="Pope" hidden="false" collective="false" import="true" type="model">
@@ -19482,6 +20589,7 @@
                 <selectionEntry id="8db4-c824-b011-96dc" name="Pope" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19489,6 +20597,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d048-0559-06ce-7122" name="Stewart" hidden="false" collective="false" import="true" type="model">
@@ -19502,6 +20611,7 @@
                 <selectionEntry id="a867-720a-8e97-7c82" name="Stewart" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19509,6 +20619,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1338-23dc-33c8-bd81" name="Clemson-Class" hidden="false" collective="false" import="true" type="model">
@@ -19522,6 +20633,7 @@
                 <selectionEntry id="81a8-15b9-917d-b129" name="Clemson-Class" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19529,11 +20641,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8af3-8694-8b01-388a" name="Farragut-Class Destroyer" hidden="false" collective="false" import="true" type="unit">
@@ -19553,26 +20667,31 @@
                 <selectionEntry id="e568-3736-b283-8071" name="Aylwin" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c7c1-5849-3bb7-dce2" name="Aylwin 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d293-24dc-2857-42a0" name="Aylwin 1942a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c298-acb8-1289-dc6d" name="Aylwin 1942b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1242-41c1-13f5-4854" name="Aylwin 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19580,6 +20699,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2737-c8c3-5c76-b0be" name="Dale" hidden="false" collective="false" import="true" type="model">
@@ -19593,31 +20713,37 @@
                 <selectionEntry id="b4a8-4d86-15cc-4d74" name="Dale" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1e94-56d5-a75b-a3b0" name="Dale 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="060c-d208-d779-8020" name="Dale 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e3ca-d80d-5d49-934c" name="Dale 1943a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="928b-b1c6-ddf3-e865" name="Dale 1943b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c640-b0fd-bf26-6ffd" name="Dale 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19625,6 +20751,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6027-15bf-fd4f-03ec" name="Dewey" hidden="false" collective="false" import="true" type="model">
@@ -19638,31 +20765,37 @@
                 <selectionEntry id="bbd3-80f2-e825-f180" name="Dewey" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="856c-2067-54bb-6d91" name="Dewey 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a5da-1ae9-db8c-f65d" name="Dewey 1942a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="27f4-4634-69bf-0062" name="Dewey 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5f5a-558b-18a0-b458" name="Dewey 1942b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="46b3-797c-1837-afc2" name="Dewey 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19670,6 +20803,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0896-c958-1ce3-6715" name="Farragut" hidden="false" collective="false" import="true" type="model">
@@ -19683,26 +20817,31 @@
                 <selectionEntry id="fac6-f7d1-7a3a-cce1" name="Farragut" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0c6c-2bd2-40d9-b649" name="Farragut 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="af23-270f-82cc-a7ef" name="Farragut 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="21c1-2d61-5fa8-0e40" name="Farragut 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1ffd-78f3-964b-b7a7" name="Farragut 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19710,6 +20849,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a8e5-48c5-0574-fe2d" name="Hull" hidden="false" collective="false" import="true" type="model">
@@ -19723,26 +20863,31 @@
                 <selectionEntry id="476a-7edd-2a7e-549a" name="Hull" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2ee4-b17e-38d9-a2a9" name="Hull 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="366b-5ccc-4585-e2bf" name="Hull 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="529a-9e31-3302-846e" name="Hull 1943a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="41ad-52eb-cd9e-a9e7" name="Hull 1943b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19750,6 +20895,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3700-c553-4fb8-5f58" name="Macdonough" hidden="false" collective="false" import="true" type="model">
@@ -19763,31 +20909,37 @@
                 <selectionEntry id="4a23-d92f-e804-e1fd" name="Macdonough" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="212a-2881-5586-2a7d" name="Macdonough 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="26a0-e44c-1ab5-fddd" name="Macdonough 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="43b9-5184-d4ba-cbd4" name="Macdonough 1943a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7909-89d1-f8fb-c630" name="Macdonough 1943b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c7fc-a806-1354-d81c" name="Macdonough 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19795,6 +20947,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9a92-c4ad-2ff9-cfd3" name="Monaghan" hidden="false" collective="false" import="true" type="model">
@@ -19808,31 +20961,37 @@
                 <selectionEntry id="a8d0-03ca-b9f1-19b3" name="Monaghan" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2038-9bc5-7657-0835" name="Monaghan 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="52c9-438d-4423-0406" name="Monaghan 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e684-467d-cdb4-80d3" name="Monaghan 1943a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9e9f-c57b-a19a-242c" name="Monaghan 1943b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="04ab-904b-aa95-0e87" name="Monaghan 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19840,6 +20999,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e0b0-cb40-9186-12ad" name="Worden" hidden="false" collective="false" import="true" type="model">
@@ -19853,26 +21013,31 @@
                 <selectionEntry id="6d53-3b9a-3b91-e05d" name="Worden" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="72b7-76b4-5bea-468c" name="Worden 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d2d5-9e49-14dd-2968" name="Worden 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6874-f6b1-f808-edf1" name="Worden 1943a" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fbae-3478-010d-82d3" name="Worden 1943b" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19880,11 +21045,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="db9c-9e30-7a10-deda" name="Gleaves-Class Destroyer" hidden="false" collective="false" import="true" type="unit">
@@ -19904,26 +21071,31 @@
                 <selectionEntry id="8060-96de-71bd-9ba5" name="Eberle" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="98d4-8726-2114-1f9d" name="Eberle 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7301-78b3-fde7-31a4" name="Eberle 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c7fe-2c81-af44-b28d" name="Eberle 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="283e-9598-2b2c-ddd6" name="Eberle 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19931,6 +21103,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c63b-00a9-ab6f-e60a" name="Edison" hidden="false" collective="false" import="true" type="model">
@@ -19944,26 +21117,31 @@
                 <selectionEntry id="cf2d-583c-a711-cfed" name="Edison" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="52ee-7486-1603-cffe" name="Edison 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e26b-c7b6-007c-60dd" name="Edison 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7d55-abee-3f44-981b" name="Edison 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a7be-8c29-c971-339f" name="Edison 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -19971,6 +21149,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ee54-2bcc-54ee-6beb" name="Ericsson" hidden="false" collective="false" import="true" type="model">
@@ -19984,26 +21163,31 @@
                 <selectionEntry id="9e3d-6596-d662-84b0" name="Ericsson" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="98e3-79d3-480f-bc28" name="Ericsson 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="47e2-e06d-6fe7-6c20" name="Ericsson 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c133-8073-6bc3-8c11" name="Ericsson 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="85a5-f73e-0554-e281" name="Ericsson 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20011,6 +21195,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7951-cb2d-28ed-5864" name="Grayson" hidden="false" collective="false" import="true" type="model">
@@ -20024,21 +21209,25 @@
                 <selectionEntry id="d499-fa6f-598b-5b68" name="Grayson" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="65e9-b7e6-9206-2173" name="Grayson 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4a24-5f78-d261-71c1" name="Grayson 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="831c-6de5-5c44-e752" name="Grayson 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20046,6 +21235,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d70c-23c9-d03d-0b3e" name="Gwin" hidden="false" collective="false" import="true" type="model">
@@ -20059,16 +21249,19 @@
                 <selectionEntry id="6e86-d810-ad21-f300" name="Gwin" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2198-7cbb-193c-95a4" name="Gwin 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bbc0-44d7-2732-c0cf" name="Gwin 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20076,6 +21269,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f668-cbbe-b1a8-e272" name="Ingraham" hidden="false" collective="false" import="true" type="model">
@@ -20089,11 +21283,13 @@
                 <selectionEntry id="288f-1f20-7e1f-f9ae" name="Ingraham" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="aec6-8d85-1f91-4764" name="Ingraham 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20101,6 +21297,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0c47-174a-ac59-f70a" name="Kearny" hidden="false" collective="false" import="true" type="model">
@@ -20114,26 +21311,31 @@
                 <selectionEntry id="ea12-7470-d06d-c48d" name="Kearny" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f6a1-864b-47b7-3475" name="Kearny 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d17b-51d7-e993-d03e" name="Kearny 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="80f0-a830-ef10-18b4" name="Kearny 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="de6d-0768-c6ed-887d" name="Kearny 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20141,6 +21343,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="be95-d3f8-247a-4274" name="Gleaves" hidden="false" collective="false" import="true" type="model">
@@ -20154,26 +21357,31 @@
                 <selectionEntry id="33b4-9da8-3dd4-42af" name="Gleaves" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5358-681d-6f4b-4452" name="Gleaves 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dd70-7f59-7539-8763" name="Gleaves 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dc9d-feca-e7ce-6e21" name="Gleaves 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="88d6-4484-2fb4-f6e7" name="Gleaves 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20181,6 +21389,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a1b1-9373-cdfa-a57d" name="Livermore" hidden="false" collective="false" import="true" type="model">
@@ -20194,26 +21403,31 @@
                 <selectionEntry id="a882-74f7-a3e3-a3fb" name="Livermore" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e7e3-fc87-1dee-71d8" name="Livermore 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="417e-9c7f-cca8-0323" name="Livermore 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f806-9922-65fa-5f32" name="Livermore 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a724-86b0-3995-8409" name="Livermore 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20221,6 +21435,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c765-b147-6acc-4d74" name="Ludlow" hidden="false" collective="false" import="true" type="model">
@@ -20234,21 +21449,25 @@
                 <selectionEntry id="426f-f4ca-1b4b-4b10" name="Ludlow" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2cc6-c95b-3a84-3879" name="Ludlow 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="645b-b13c-f612-935c" name="Ludlow 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6505-9bff-c1d4-f727" name="Ludlow 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20256,6 +21475,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="aa9a-6d69-6626-f55e" name="Meredith" hidden="false" collective="false" import="true" type="model">
@@ -20269,11 +21489,13 @@
                 <selectionEntry id="ba9f-1bca-ac59-1aa2" name="Meredith" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1e24-169a-1377-cf29" name="Meredith 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20281,6 +21503,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="161c-930f-5688-ea3e" name="Monssen" hidden="false" collective="false" import="true" type="model">
@@ -20294,11 +21517,13 @@
                 <selectionEntry id="6588-8ae9-ba6c-f40e" name="Monssen" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8e27-ba8c-da9c-e076" name="Monssen 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20306,6 +21531,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="547e-01c4-6e1d-b4ee" name="Niblack" hidden="false" collective="false" import="true" type="model">
@@ -20319,26 +21545,31 @@
                 <selectionEntry id="c3a3-095f-902f-748b" name="Niblack" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1de2-322a-e5c3-06de" name="Niblack 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6952-4b92-093d-3050" name="Niblack 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0949-32cb-d73b-7368" name="Niblack 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="aeb4-7748-bbe0-d5bb" name="Niblack 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20346,6 +21577,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a641-3708-ad8d-09bf" name="Nicholson" hidden="false" collective="false" import="true" type="model">
@@ -20359,21 +21591,25 @@
                 <selectionEntry id="d370-0127-b209-f877" name="Nicholson" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7e86-0fde-f117-afeb" name="Nicholson 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="72ab-3a89-ca39-e971" name="Nicholson 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="216d-ef16-db9b-2b7b" name="Nicholson 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20381,6 +21617,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cfd9-6854-d480-4de0" name="Plunkett" hidden="false" collective="false" import="true" type="model">
@@ -20394,26 +21631,31 @@
                 <selectionEntry id="132b-1674-aefc-0e90" name="Plunkett" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0415-d8ec-a61d-661f" name="Plunkett 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ad1c-9124-bd6c-b047" name="Plunkett 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fdad-762f-a74d-c5b8" name="Plunkett 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5631-a105-b848-955a" name="Plunkett 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20421,6 +21663,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="13fd-ba64-385a-775d" name="Swanson" hidden="false" collective="false" import="true" type="model">
@@ -20434,21 +21677,25 @@
                 <selectionEntry id="956b-d08f-bdb3-3979" name="Swanson" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cc0b-55ea-1e5a-f513" name="Swanson 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6649-0442-b1a2-e6ac" name="Swanson 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a81c-623b-a212-9525" name="Swanson 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20456,6 +21703,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7f02-17a9-9ec6-4727" name="Wilkes" hidden="false" collective="false" import="true" type="model">
@@ -20469,16 +21717,19 @@
                 <selectionEntry id="f8a4-bde3-61d5-38a1" name="Wilkes" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9e9f-30ab-dda2-e424" name="Wilkes 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="389a-e516-2ffb-0ad0" name="Wilkes 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20486,6 +21737,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f00e-89be-bd86-a804" name="Woolsey" hidden="false" collective="false" import="true" type="model">
@@ -20499,21 +21751,25 @@
                 <selectionEntry id="de02-aa4d-b9a7-f680" name="Woolsey" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c77b-65fd-5fce-0a50" name="Woolsey 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="edf9-54aa-7b5e-c633" name="Woolsey 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9bba-d1a2-6b09-3095" name="Woolsey 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20521,11 +21777,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e807-c820-1bf0-5cb6" name="Gridley-Class Destroyer" hidden="false" collective="false" import="true" type="unit">
@@ -20545,21 +21803,25 @@
                 <selectionEntry id="4379-0d4e-0404-5e65" name="Craven" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1fbc-08b1-b74c-a95f" name="Craven 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ad1c-2dad-3783-5bae" name="Craven 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3dde-24c5-8bad-7567" name="Craven 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20567,6 +21829,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="df53-ca2c-d286-cbb7" name="Gridley" hidden="false" collective="false" import="true" type="model">
@@ -20580,21 +21843,25 @@
                 <selectionEntry id="cf7b-2988-e6a0-f954" name="Gridley" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9cb9-85cb-4266-154b" name="Gridley 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2c17-4e12-af23-4af2" name="Gridley 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="83ba-8819-1a85-a7f5" name="Gridley 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20602,6 +21869,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f56f-a9f7-b2f4-2091" name="McCall" hidden="false" collective="false" import="true" type="model">
@@ -20615,21 +21883,25 @@
                 <selectionEntry id="a640-a02e-51e9-cfdb" name="McCall" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="acb2-9b26-b9d2-6745" name="McCall 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c4b1-9298-e87a-1966" name="McCall 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b5fe-de44-9ecb-b57f" name="McCall 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20637,6 +21909,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4897-c51b-70ea-e9f9" name="Maury" hidden="false" collective="false" import="true" type="model">
@@ -20650,21 +21923,25 @@
                 <selectionEntry id="b90a-adb7-dc28-2ea8" name="Maury" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="36aa-d3df-801d-4615" name="Maury 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e4a1-a8dd-0313-4d4a" name="Maury 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6d4e-5743-8e9c-23f2" name="Maury 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20672,11 +21949,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="36e9-662e-929f-606c" name="John C Bulter-Class Destroyer" hidden="false" collective="false" import="true" type="unit">
@@ -20696,11 +21975,13 @@
                 <selectionEntry id="9b16-3198-6044-24b5" name="John C. Butler" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="01f4-1dee-8ebb-9b40" name="John C. Butler 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20708,6 +21989,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3a28-bcc6-7a1f-f1d4" name="O&apos;Flaherty" hidden="false" collective="false" import="true" type="model">
@@ -20721,11 +22003,13 @@
                 <selectionEntry id="0837-2b0c-a572-a212" name="O&apos;Flaherty" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5c05-324d-d76e-649e" name="O&apos;Flaherty 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20733,6 +22017,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d8db-ac2a-c1c1-9a16" name="Raymond" hidden="false" collective="false" import="true" type="model">
@@ -20746,11 +22031,13 @@
                 <selectionEntry id="9917-58e4-de9d-b6e5" name="Raymond" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5318-80f4-40ef-2124" name="Raymond 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20758,6 +22045,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0534-aed9-f0ad-5092" name="Richard W. Susens" hidden="false" collective="false" import="true" type="model">
@@ -20771,11 +22059,13 @@
                 <selectionEntry id="02c8-934b-eab1-d5b2" name="Richard W. Susens" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d4fc-cc58-ab73-9550" name="Richard W. Susens 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20783,6 +22073,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0f89-e8d5-01f9-dd6f" name="Abercrombie" hidden="false" collective="false" import="true" type="model">
@@ -20796,11 +22087,13 @@
                 <selectionEntry id="60c9-6c55-ff45-758c" name="Abercrombie" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ec38-9773-7e90-b5e8" name="Abercrombie 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20808,6 +22101,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6587-1e03-d3bc-ce1b" name="Oberrender" hidden="false" collective="false" import="true" type="model">
@@ -20821,11 +22115,13 @@
                 <selectionEntry id="ada2-b237-726c-b63d" name="Oberrender" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d23d-65db-08a8-befe" name="Oberrender 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20833,6 +22129,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cca8-238b-9db6-9a31" name="Robert Brazier" hidden="false" collective="false" import="true" type="model">
@@ -20846,11 +22143,13 @@
                 <selectionEntry id="c711-b613-c13f-a3f2" name="Robert Brazier" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="706a-5732-9ca8-eb01" name="Robert Brazier 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20858,6 +22157,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="98ed-64fd-a525-2131" name="Edwin A. Howard" hidden="false" collective="false" import="true" type="model">
@@ -20871,11 +22171,13 @@
                 <selectionEntry id="375d-5a63-0227-c99d" name="Edwin A. Howard" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e591-479b-eee8-cf9b" name="Edwin A. Howard 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20883,6 +22185,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2b9f-682b-eb51-9b07" name="Jesse Rutherford" hidden="false" collective="false" import="true" type="model">
@@ -20896,11 +22199,13 @@
                 <selectionEntry id="3595-96a6-42b0-dc71" name="Jesse Rutherford" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f5d0-a691-b1c1-ad31" name="Jesse Rutherford 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20908,6 +22213,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ccb5-1ab9-95df-e62f" name="Key" hidden="false" collective="false" import="true" type="model">
@@ -20921,11 +22227,13 @@
                 <selectionEntry id="174e-7c2b-1922-63e9" name="Key" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7e4d-8e5c-d1cc-c91f" name="Key 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20933,6 +22241,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7919-04ab-99e6-fcd7" name="John C. Butler-Class" hidden="false" collective="false" import="true" type="model">
@@ -20946,11 +22255,13 @@
                 <selectionEntry id="f363-ac54-e50a-52e9" name="John C. Bulter-Class" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2178-321b-fbde-03c0" name="John C. Butler-Class 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="-5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20958,11 +22269,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d6e0-7e6b-94b9-6538" name="Mahan-Class Destroyer" hidden="false" collective="false" import="true" type="unit">
@@ -20982,16 +22295,19 @@
                 <selectionEntry id="20a2-f802-aad5-b689" name="Case" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="947e-b4a0-a252-8108" name="Case 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4558-20e1-b2e2-0979" name="Case 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -20999,6 +22315,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1ce9-b8c6-1ebd-8870" name="Cassin" hidden="false" collective="false" import="true" type="model">
@@ -21012,11 +22329,13 @@
                 <selectionEntry id="2a00-0cf7-ab99-890d" name="Cassin" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2004-f87f-4228-bfb2" name="Cassin 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21024,6 +22343,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d1f1-f27d-3837-703c" name="Coyngham" hidden="false" collective="false" import="true" type="model">
@@ -21037,21 +22357,25 @@
                 <selectionEntry id="4066-cd12-dc8c-aefa" name="Coyngham" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6ca0-0862-17cd-8f15" name="Coyngham 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e415-5774-68f8-d35a" name="Coyngham 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="29a7-8643-56e0-2f36" name="Coyngham 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21059,6 +22383,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="21fb-e943-df46-8fc0" name="Cummings" hidden="false" collective="false" import="true" type="model">
@@ -21072,21 +22397,25 @@
                 <selectionEntry id="c413-ded4-6523-965f" name="Cummings" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="710c-9c05-17f3-cfea" name="Cummings 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2577-a5de-7fe8-b59a" name="Cummings 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5b60-539c-573e-23eb" name="Cummings 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21094,6 +22423,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9d3f-46c0-f91b-7d9c" name="Cushing" hidden="false" collective="false" import="true" type="model">
@@ -21107,11 +22437,13 @@
                 <selectionEntry id="f1e2-e1c0-88cb-60cc" name="Cushing" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ddff-7be6-6d52-84f1" name="Cushing 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21119,6 +22451,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="237d-8bfb-a72f-6148" name="Downes" hidden="false" collective="false" import="true" type="model">
@@ -21132,11 +22465,13 @@
                 <selectionEntry id="4fd3-37c8-33cb-46ad" name="Downes" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6d49-e3aa-098b-725d" name="Downes 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21144,6 +22479,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9ed9-50bd-6d60-bc3b" name="Drayton" hidden="false" collective="false" import="true" type="model">
@@ -21157,16 +22493,19 @@
                 <selectionEntry id="3b0f-1684-5923-ec11" name="Drayton" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a5e7-79b4-d902-ade7" name="Drayton 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6197-f090-58cf-17d1" name="Drayton 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21174,6 +22513,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ba7a-c851-a1e6-e68d" name="Dunlap" hidden="false" collective="false" import="true" type="model">
@@ -21187,21 +22527,25 @@
                 <selectionEntry id="d26a-75e2-c31f-ac38" name="Dunlap" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e8d5-d3a2-17d9-bdf7" name="Dunlap 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0ada-eddf-8f50-1ed7" name="Dunlap 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2dfc-ca94-4306-2262" name="Dunlap 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21209,6 +22553,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="36e2-f481-7700-d5cd" name="Fanning" hidden="false" collective="false" import="true" type="model">
@@ -21222,16 +22567,19 @@
                 <selectionEntry id="afa4-9b67-e5e4-8e9b" name="Fanning" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="82aa-9fbc-ad58-0ed9" name="Fanning 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d5ed-ff5f-b0cb-fa31" name="Fanning 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21239,6 +22587,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="50df-ae60-6af8-7bfc" name="Flusser" hidden="false" collective="false" import="true" type="model">
@@ -21252,16 +22601,19 @@
                 <selectionEntry id="a127-4f1a-be0f-714b" name="Flusser" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="af2a-db90-b6d8-690c" name="Flusser 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cfbb-7acf-3528-173d" name="Flusser 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21269,6 +22621,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="93eb-ebe8-fbe7-87f4" name="Lamson" hidden="false" collective="false" import="true" type="model">
@@ -21282,21 +22635,25 @@
                 <selectionEntry id="7dc7-c8f5-c222-9110" name="Lamson" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5c58-703c-f990-3362" name="Lamson 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="562e-635b-6341-b623" name="Lamson 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a121-8ea3-6bc9-8812" name="Lamson 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21304,6 +22661,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0977-d07a-eadb-2645" name="Mahan" hidden="false" collective="false" import="true" type="model">
@@ -21317,16 +22675,19 @@
                 <selectionEntry id="d20b-89d2-770b-0716" name="Mahan" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="46f7-f3d7-114c-0775" name="Mahan 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d229-e540-768e-f640" name="Mahan 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21334,6 +22695,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6b74-f159-b2de-0c8d" name="Perkins" hidden="false" collective="false" import="true" type="model">
@@ -21347,16 +22709,19 @@
                 <selectionEntry id="ea26-0213-6db0-8f04" name="Perkins" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="674b-3e63-5d00-7dbf" name="Perkins 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3f9d-352a-875d-3ae5" name="Perkins 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21364,6 +22729,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="11d7-d7a3-dcdc-c057" name="Preston" hidden="false" collective="false" import="true" type="model">
@@ -21377,11 +22743,13 @@
                 <selectionEntry id="05fa-8bd6-079c-32af" name="Preston" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e621-1b78-5b1f-6a2b" name="Preston 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21389,6 +22757,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7c0a-8381-8b12-0e81" name="Reid" hidden="false" collective="false" import="true" type="model">
@@ -21402,16 +22771,19 @@
                 <selectionEntry id="7ff5-6878-2d4c-533d" name="Reid" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fb65-5c40-b1cd-fcff" name="Reid 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f1f7-106a-9279-8219" name="Reid 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21419,6 +22791,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d060-d9a2-3091-3f6b" name="Shaw" hidden="false" collective="false" import="true" type="model">
@@ -21432,21 +22805,25 @@
                 <selectionEntry id="a833-fb58-eba4-cdc3" name="Shaw" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9a9a-997f-7e13-b34a" name="Shaw 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c316-ae73-1963-f008" name="Shaw 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6989-94b4-2c21-123f" name="Shaw 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21454,6 +22831,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2d92-b09d-f019-a8bb" name="Smith" hidden="false" collective="false" import="true" type="model">
@@ -21467,16 +22845,19 @@
                 <selectionEntry id="4269-3fea-154e-187b" name="Smith 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4b60-cf63-ad1f-9c02" name="Smith" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9395-1694-d42c-c1d8" name="Smith 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21484,6 +22865,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d3b5-e004-41cc-29f4" name="Tucker" hidden="false" collective="false" import="true" type="model">
@@ -21497,11 +22879,13 @@
                 <selectionEntry id="e311-8c39-30e2-cb84" name="Tucker 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ef35-1b47-e459-1106" name="Tucker" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21509,11 +22893,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8b11-71a5-fb33-a184" name="Porter-Class Destroyer Leader" hidden="false" collective="false" import="true" type="unit">
@@ -21533,26 +22919,31 @@
                 <selectionEntry id="6b0f-2faa-8eb9-b3ff" name="Balch" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3b9f-0281-6f48-d484" name="Balch 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1551-da78-a06e-73fe" name="Balch 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9cc8-423a-a815-9391" name="Balch 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="13ab-dc84-ef86-10b1" name="Balch 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21560,6 +22951,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9624-4ab3-1a78-2f01" name="Clark" hidden="false" collective="false" import="true" type="model">
@@ -21573,26 +22965,31 @@
                 <selectionEntry id="cbbc-de10-f0f5-6841" name="Clark" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a9ca-f11b-517d-608c" name="Clark 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e74f-7815-4ac1-bad7" name="Clark 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7a84-f6d3-4147-7167" name="Clark 1843" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dade-c2df-1a63-7c69" name="Clark 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21600,6 +22997,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a810-cbee-5ba3-2109" name="McDougal" hidden="false" collective="false" import="true" type="model">
@@ -21613,31 +23011,37 @@
                 <selectionEntry id="20d9-a133-c726-5d99" name="McDougal" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f282-9c30-ba72-9a6b" name="McDougal 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="57f4-cb5f-2624-f96f" name="McDougal 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2cb4-28de-e521-a587" name="McDougal 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="507c-b1fb-a2b3-4d7e" name="McDougal 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f602-13ef-63cd-25b8" name="McDougal 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21645,6 +23049,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0c1b-4890-e203-36eb" name="Moffet" hidden="false" collective="false" import="true" type="model">
@@ -21658,26 +23063,31 @@
                 <selectionEntry id="f479-c719-75a0-08f3" name="Moffet" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ac82-0472-5438-1a45" name="Moffet 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="73c4-4b69-a0a4-61c6" name="Moffet 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a2fd-00d5-6ebb-240c" name="Moffet 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cd1a-48c3-dd0b-bd25" name="Moffet 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21685,6 +23095,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6918-f032-4e2f-ba59" name="Phelps" hidden="false" collective="false" import="true" type="model">
@@ -21698,31 +23109,37 @@
                 <selectionEntry id="03f8-381b-4a22-82cd" name="Phelps" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="016b-9bf9-bbad-285b" name="Phelps 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ac06-2db5-cfab-1782" name="Phelps 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7c74-c1cf-f2a5-8734" name="Phelps 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7863-09cb-1797-f5d2" name="Phelps 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cb46-c1d4-51d6-d938" name="Phelps 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21730,6 +23147,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="aabe-f56c-bee2-d4b3" name="Selfridge" hidden="false" collective="false" import="true" type="model">
@@ -21743,26 +23161,31 @@
                 <selectionEntry id="60bc-54b9-b238-35de" name="Selfridge" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="410d-0a42-e6c5-a389" name="Selfridge 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e28c-f795-a3a5-d4db" name="Selfridge 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="bd0a-bab3-f9a1-2697" name="Selfridge 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="76d0-4535-04a2-2e76" name="Selfridge 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21770,6 +23193,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="606f-275b-542e-589b" name="Winslow" hidden="false" collective="false" import="true" type="model">
@@ -21783,31 +23207,37 @@
                 <selectionEntry id="c7e2-d479-ed5c-7aa0" name="Winslow" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5cb2-0bab-85a2-9aca" name="Winslow 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8332-d66c-941f-fec4" name="Winslow 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1e2b-5a9c-8227-1c3e" name="Winslow 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c4e6-cb92-8c39-336c" name="Winslow 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e8b4-28a5-cb29-84e8" name="Winslow 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21815,6 +23245,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2227-a665-5e88-a432" name="Porter" hidden="false" collective="false" import="true" type="model">
@@ -21828,16 +23259,19 @@
                 <selectionEntry id="d278-5632-dc0e-1394" name="Porter" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="762d-8d14-6147-dab3" name="Porter 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9959-2814-0b96-3bbc" name="Porter 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21845,11 +23279,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="55.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5d04-5025-71ae-c78f" name="Sims-Class Destroyer" hidden="false" collective="false" import="true" type="unit">
@@ -21869,26 +23305,31 @@
                 <selectionEntry id="d61b-3389-127b-d3be" name="Anderson" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3624-152f-d810-a3c6" name="Anderson 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="24bb-dae8-fcdb-a863" name="Anderson 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4dc2-48fb-3374-70c6" name="Anderson 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="aa7c-85a7-f24d-4a4c" name="Anderson 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21896,6 +23337,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="067c-73a2-d295-623f" name="Buck" hidden="false" collective="false" import="true" type="model">
@@ -21909,21 +23351,25 @@
                 <selectionEntry id="c79a-ad0d-2b47-7247" name="Buck" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4069-7b43-171e-9657" name="Buck 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8e31-deac-1be5-2a7b" name="Buck 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8892-282e-4fd3-d864" name="Buck 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21931,6 +23377,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="187e-ee9b-2a5c-e031" name="Hammann" hidden="false" collective="false" import="true" type="model">
@@ -21944,21 +23391,25 @@
                 <selectionEntry id="2f33-cb77-e527-42ba" name="Hammann" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="98da-7b83-77da-e446" name="Hammann 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="23f9-58ea-7abd-4ba9" name="Hammann 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="229c-63c8-b7f9-4cf2" name="Hammann 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -21966,6 +23417,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f4f1-8501-55f4-8d38" name="Hughes" hidden="false" collective="false" import="true" type="model">
@@ -21979,21 +23431,25 @@
                 <selectionEntry id="bb4a-11c0-5e82-21ac" name="Hughes" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7957-a522-2456-8f6d" name="Hughes 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e60d-ab78-06fd-f29f" name="Hughes 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="b1a4-d813-bb82-d6ab" name="Hughes 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -22001,6 +23457,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d358-f7ff-a62c-bfa2" name="Morris" hidden="false" collective="false" import="true" type="model">
@@ -22014,26 +23471,31 @@
                 <selectionEntry id="8ff4-5121-84a7-2ce3" name="Morris" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7a79-a6d4-b648-45eb" name="Morris 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6990-9e99-f0ef-db48" name="Morris 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6747-4dad-186f-b8ec" name="Morris 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7beb-8aab-6a72-b504" name="Morris 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -22041,6 +23503,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3a12-18a8-0246-4fe2" name="Mustin" hidden="false" collective="false" import="true" type="upgrade">
@@ -22054,31 +23517,37 @@
                 <selectionEntry id="9985-ae6b-207a-abbb" name="Mustin" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fc4b-dd98-0ee3-b9c0" name="Mustin 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5d45-e352-b0e4-75f3" name="Mustin 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5e4b-97cf-33d5-e617" name="Mustin 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dd71-5b15-01e4-85a3" name="Mustin 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="192c-58da-7657-4cba" name="Mustin 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -22086,6 +23555,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dc9f-59bc-d815-e1f2" name="O&apos;Brien" hidden="false" collective="false" import="true" type="model">
@@ -22099,16 +23569,19 @@
                 <selectionEntry id="b615-1812-9b0b-9e17" name="O&apos;Brien" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e935-d4b1-c105-4f90" name="O&apos;Brien 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c7b3-d8d4-df58-6a59" name="O&apos;Brien 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -22116,6 +23589,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2804-ecd0-fe36-a003" name="Roe" hidden="false" collective="false" import="true" type="model">
@@ -22129,21 +23603,25 @@
                 <selectionEntry id="676b-8dc8-c9c0-f436" name="Roe" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="6e78-3271-c9f3-c408" name="Roe 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a331-c0df-1357-2ffb" name="Roe 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4a59-a63b-256c-1634" name="Roe 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -22151,6 +23629,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0428-d360-5eaf-0d5a" name="Russell" hidden="false" collective="false" import="true" type="model">
@@ -22164,26 +23643,31 @@
                 <selectionEntry id="6007-8496-cf71-1603" name="Russell" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8446-c2fa-2cc7-ba95" name="Russell 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="fb07-99d9-5911-d80e" name="Russell 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cd54-bfa3-3096-c940" name="Russell 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4aa2-51a0-7c50-917f" name="Russell 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -22191,6 +23675,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7992-e3ed-e728-43b7" name="Sims" hidden="false" collective="false" import="true" type="model">
@@ -22204,21 +23689,25 @@
                 <selectionEntry id="10ae-727c-f6f8-3f24" name="Sims" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="875c-28d8-0e84-c0df" name="Sims 1940" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5344-c209-f390-2bfe" name="Sims 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="286b-53cd-5aa8-d824" name="Sims 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -22226,6 +23715,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="03b3-89d5-bedd-bf27" name="Wainwright" hidden="false" collective="false" import="true" type="model">
@@ -22239,31 +23729,37 @@
                 <selectionEntry id="b482-8e85-d339-46d4" name="Wainwright" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d9c2-c06d-3770-7439" name="Wainwright 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="75b0-8e62-dc53-cfc1" name="Wainwright 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="7e22-730d-2a4d-e4eb" name="Wainwright 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3a31-48a1-aee0-4156" name="Wainwright 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5c42-8926-3ae9-3cbc" name="Wainwright 1945" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -22271,6 +23767,7 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a728-8d91-ed07-404c" name="Walke" hidden="false" collective="false" import="true" type="model">
@@ -22284,16 +23781,19 @@
                 <selectionEntry id="6534-8ee6-ebec-c3b3" name="Walke" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="050c-60b8-2395-2a60" name="Walke 1941" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a219-db14-06b2-268f" name="Walke 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -22301,11 +23801,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="60.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="37db-6a6a-fee2-a06e" name="Gato-Class Submarine" hidden="false" collective="false" import="true" type="unit">
@@ -22325,21 +23827,25 @@
                 <selectionEntry id="345b-94af-967f-b023" name="Gato-Class" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0b1e-a46f-c811-e4ac" name="Gato-Class 1942" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9d83-625c-f08e-5325" name="Gato-Class 1943" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="30.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0e9c-88ed-f5c7-ee3a" name="Gato-Class 1944" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="40.0"/>
+                    <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -22347,11 +23853,13 @@
           </selectionEntryGroups>
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="50.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="76f3-7203-b5e7-2858" name="Bell P-39D Airacobra - Fighter" hidden="false" collective="false" import="true" type="model">
@@ -22361,6 +23869,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="02d4-24a7-b320-64a0" name="Bell P-39D Airacobra - Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22370,6 +23879,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f787-b196-5590-814d" name="Boeing B-17D Flying Fortress - Level Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22379,6 +23889,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e7b1-db6e-a03e-065a" name="Curtiss P-40C Warhawk - Fighter" hidden="false" collective="false" import="true" type="model">
@@ -22388,6 +23899,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9d86-97df-7cc7-d7da" name="Curtiss SB2C-1 Helldiver - Dive-bomber" hidden="false" collective="false" import="true" type="model">
@@ -22397,6 +23909,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e5d5-40aa-a05f-522f" name="Douglas SBD-2 Dauntless - Dive-Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22406,6 +23919,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7e20-4555-f577-3827" name="Douglas TBD-1 Devastator - Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22415,6 +23929,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eeaf-f298-fb07-8fe1" name="Douglas TBD-1 Devastator - Torpedo-Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22423,6 +23938,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bee6-4eb3-cd24-aa3c" name="Grumman F4F-3 Wildcat - Bomber" hidden="false" collective="false" import="true" type="upgrade">
@@ -22440,11 +23956,13 @@
             <selectionEntry id="884b-f806-b552-daef" name="1940" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e1df-33fb-3226-8f05" name="1941" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -22452,6 +23970,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bedf-d209-ab36-02e1" name="Grumman F4F-3 Wildcat - Fighter" hidden="false" collective="false" import="true" type="model">
@@ -22468,11 +23987,13 @@
             <selectionEntry id="210c-4f13-d9f7-976d" name="1940" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b26-f721-aca2-7770" name="1941" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -22480,6 +24001,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aef2-f27c-37f6-f5ea" name="Grumman F6F-3 Hellcat - Fighter" hidden="false" collective="false" import="true" type="model">
@@ -22489,6 +24011,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2457-a900-ea4b-5bdb" name="Grumman TBF-1/TBM-1C Avenger - ASW" hidden="false" collective="false" import="true" type="model">
@@ -22498,6 +24021,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="42e1-7417-b78e-77a0" name="Grumman TBF-1C/TBM-1C Avenger - Torpedo-Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22507,6 +24031,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5049-d2f8-f83f-d003" name="Lockheed Hudson - Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22516,6 +24041,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d197-be57-b5d2-5f93" name="North American B-25C Mitchell - Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22525,6 +24051,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cc66-4bd7-e965-00d3" name="North American B-25C Mitchell - Torpedo-Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22534,6 +24061,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1721-4e2d-0b13-8842" name="North American B-25C Mitchell - ASW" hidden="false" collective="false" import="true" type="model">
@@ -22543,6 +24071,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="814f-86f8-62f2-a933" name="Consolidated BPY-2/3/4 Catalina - ASW" hidden="false" collective="false" import="true" type="model">
@@ -22552,6 +24081,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dcde-3f4f-ccaa-0278" name="Consolidated PBY-2/3/4 Catalina - Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22560,6 +24090,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a35a-26a4-b93b-8c2c" name="Consolidated PBY-2/3/4 Catalina - Torpedo-Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22569,6 +24100,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="15.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e76a-0617-2bd1-29ad" name="North American P-51A Mustang - Fighter" hidden="false" collective="false" import="true" type="model">
@@ -22586,11 +24118,13 @@
             <selectionEntry id="d2b7-239c-694b-1a55" name="1941" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82fe-2f86-9768-fc6a" name="1944" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -22598,6 +24132,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="10.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c943-80d3-1d4c-e525" name="North American P-51A Mustang - Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22615,11 +24150,13 @@
             <selectionEntry id="445e-70f3-8e1f-bd63" name="1941" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24d7-7bc9-2663-b8ef" name="1944" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -22627,6 +24164,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e187-3dc3-13b8-4722" name="Vought F4U-1 Corsair - Fighter" hidden="false" collective="false" import="true" type="model">
@@ -22644,11 +24182,13 @@
             <selectionEntry id="a891-96cc-7a7d-8d0d" name="1942" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fde4-7e47-dddc-289b" name="1944" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+                <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -22656,6 +24196,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="68b5-4bc3-28e4-1241" name="Vought F4U-4 Corsair - Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22665,6 +24206,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="25.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4663-a2f9-858c-1624" name="Vought SB2U Vindicator - Dive-Bomber" hidden="false" collective="false" import="true" type="model">
@@ -22674,6 +24216,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="5.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="db5f-09fa-db60-11bc" name="Elco&apos;77 MTB" hidden="false" collective="false" import="true" type="model">
@@ -22683,6 +24226,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="802c-298f-9436-ed2a" name="Elco&apos;80 MTB" hidden="false" collective="false" import="true" type="model">
@@ -22692,6 +24236,7 @@
       </categoryLinks>
       <costs>
         <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="20.0"/>
+        <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -22701,61 +24246,73 @@
         <selectionEntry id="8d9b-caa7-c1e3-8cfe" name="Curtiss SB2C-1 Helldiver - Dive-Bomber" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7373-d86b-30e8-7830" name="Douglas TBD-2 Dauntless - Dive-Bomber" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fb0c-9adb-4621-d24a" name="Douglas TBD-1 Devastator - Bomber" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4227-04e3-1359-91c2" name="Douglas TBD-1 Devastator - Torpedo-Bomber" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a314-72cc-e545-cba7" name="Grumman F4F-3 Wildcat - Bomber" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="62bb-dab3-f379-925e" name="Grumman F4F-3 Wildcat - Fighter" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="97e3-5858-8d32-8e9c" name="Grumman F6F-3 Hellcat - Fighter" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8e57-a917-945b-72c6" name="Grumman TBF-1C/TBM-1C Avenger - ASW" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="45ff-359d-0c40-8691" name="Grumman TBF-1C/TBM-1C Avenger - Torpedo-Bomber" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c487-7c23-cd18-1cb4" name="Vought F4U-4 Corsair - Fighter" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ae4f-00c6-4966-424a" name="Vought F4U-4 Corsair - Bomber" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="92dc-1f09-3a35-c640" name="Vought SB2U Vindicator - Dive-Bomber" hidden="false" collective="false" import="true" type="model">
           <costs>
             <cost name="Points" typeId="ffdf-62d1-dc97-b85c" value="0.0"/>
+            <cost name="EPoints" typeId="8ff1-0245-6897-5c02" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>

--- a/Victory at Sea.gst
+++ b/Victory at Sea.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="d551-9646-dd17-819a" name="Victory at Sea" revision="1" battleScribeVersion="2.03" authorName="" authorContact="" authorUrl="" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="d551-9646-dd17-819a" name="Victory at Sea" revision="2" battleScribeVersion="2.03" authorName="" authorContact="" authorUrl="" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <costTypes>
     <costType id="ffdf-62d1-dc97-b85c" name="Points" defaultCostLimit="-1.0" hidden="false"/>
   </costTypes>
@@ -75,13 +75,57 @@
     <forceEntry id="9707-b4d0-2007-bbf6" name="Fleet" hidden="false">
       <categoryLinks>
         <categoryLink id="6fb2-5e78-1015-e1fb" name="Aircraft Carrier" hidden="false" targetId="da58-44be-bb7f-80d6" primary="false"/>
-        <categoryLink id="acc5-2e6d-c450-85f0" name="Aircraft Flight" hidden="false" targetId="c08d-d9af-1109-9c27" primary="false"/>
+        <categoryLink id="acc5-2e6d-c450-85f0" name="Aircraft Flight" hidden="false" targetId="c08d-d9af-1109-9c27" primary="false">
+          <constraints>
+            <constraint field="ffdf-62d1-dc97-b85c" scope="roster" value="25.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f20-c249-521b-9b81" type="max"/>
+          </constraints>
+        </categoryLink>
         <categoryLink id="774d-c64d-cc60-8055" name="Battleship" hidden="false" targetId="5153-aef8-326b-3c5f" primary="false"/>
         <categoryLink id="9e32-11d8-b894-654b" name="Cruiser" hidden="false" targetId="f46e-c2a8-5a64-daf9" primary="false"/>
         <categoryLink id="af42-cc1c-8240-7080" name="Destroyer" hidden="false" targetId="b241-6ad8-94a2-cc48" primary="false"/>
         <categoryLink id="5c5c-7031-8552-c399" name="Civilian" hidden="false" targetId="be79-ea08-0c7b-609c" primary="false"/>
-        <categoryLink id="56d4-3a9b-89a9-5f76" name="Motor Torpedo Boat" hidden="false" targetId="cf88-2062-68e4-b49a" primary="false"/>
-        <categoryLink id="5717-ceee-dad0-cac8" name="Submarine" hidden="false" targetId="3c73-d3d0-7c07-b8e5" primary="false"/>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="e2ea-c2ec-d5a8-935a" name="Coastal Fleet" hidden="false">
+      <categoryLinks>
+        <categoryLink id="c67e-ef22-7f4f-8154" name="Aircraft Carrier" hidden="false" targetId="da58-44be-bb7f-80d6" primary="false">
+          <modifiers>
+            <modifier type="set" field="e335-1285-9d29-3e78" value="0.0">
+              <conditions>
+                <condition field="selections" scope="e2ea-c2ec-d5a8-935a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5153-aef8-326b-3c5f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e335-1285-9d29-3e78" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5805-4033-1d03-055f" name="Battleship" hidden="false" targetId="5153-aef8-326b-3c5f" primary="false">
+          <modifiers>
+            <modifier type="set" field="a136-19d5-e4a1-723b" value="0.0">
+              <conditions>
+                <condition field="selections" scope="e2ea-c2ec-d5a8-935a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="da58-44be-bb7f-80d6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a136-19d5-e4a1-723b" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="e92f-2e02-4c18-d459" name="Cruiser" hidden="false" targetId="f46e-c2a8-5a64-daf9" primary="false"/>
+        <categoryLink id="dfe8-ba81-dba1-46e4" name="Destroyer" hidden="false" targetId="b241-6ad8-94a2-cc48" primary="false"/>
+        <categoryLink id="eb73-d06e-800c-ee52" name="Motor Torpedo Boat" hidden="false" targetId="cf88-2062-68e4-b49a" primary="false"/>
+        <categoryLink id="306a-fbf6-1963-e82b" name="Aircraft Flight" hidden="false" targetId="c08d-d9af-1109-9c27" primary="false">
+          <constraints>
+            <constraint field="ffdf-62d1-dc97-b85c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="false" id="aecb-1c8f-7924-f903" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5fd1-7263-858b-ec2e" name="Civilian" hidden="false" targetId="be79-ea08-0c7b-609c" primary="false"/>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="a81a-be20-0aa5-2513" name="Submarine Fleet" hidden="false">
+      <categoryLinks>
+        <categoryLink id="42fe-f08c-9d1a-295f" name="Submarine" hidden="false" targetId="3c73-d3d0-7c07-b8e5" primary="false"/>
       </categoryLinks>
     </forceEntry>
   </forceEntries>


### PR DESCRIPTION
I have split the standard fleet now into three with Fleet being the ocean fleet with no mbts, a coastal fleet with mbts but limited capital ships and a submarine fleet with just subs

I have also fixed a couple of errors with US carriers with the wrong or no flight options